### PR TITLE
[Resolved] use safeAreaLayoutGuide for ios 11 and NSLayoutConstraint for ios 10 to fix elementView bad position depending status bar visibility

### DIFF
--- a/extra/renderer-and-libwebrtc-tests.js
+++ b/extra/renderer-and-libwebrtc-tests.js
@@ -194,7 +194,7 @@ function TestRTCPeerConnection(localStream) {
   };
 
   pc1.onnegotiationneeded = function (e) {
-    console.log('negotiatioNneeded', e);
+    console.log('negotiatioNeeded', e);
 
     return pc1.createOffer().then(function (d) {
       return pc1.setLocalDescription(d);

--- a/extra/renderer-and-libwebrtc-tests.js
+++ b/extra/renderer-and-libwebrtc-tests.js
@@ -1,7 +1,9 @@
+/* global RTCPeerConnection, MediaStream */
 
 //
 // Camera and Microphone Authorization   
 //
+
 /*
 cordova.plugins.diagnostic.requestMicrophoneAuthorization(function (status) {
     if(status === cordova.plugins.diagnostic.permissionStatus.GRANTED) {
@@ -103,7 +105,7 @@ function TestPluginMediaStreamRenderer(localVideoEl) {
       cordova.plugins.iosrtc.refreshVideos();
     }
 
-    return animateTimer = requestAnimationFrame(animateVideo);
+    return (animateTimer = requestAnimationFrame(animateVideo));
   }
 
   animateTimer = animateVideo();
@@ -157,7 +159,8 @@ function TestRTCPeerConnection(localStream) {
     return can && pc.addIceCandidate(can).catch(function (err) {
       console.log('addIceCandidateError', err);
     });
-  };
+  }
+
   pc1.onicecandidate = function (e) {
     return onAddIceCandidate(pc2, e.candidate);
   };
@@ -186,15 +189,13 @@ function TestRTCPeerConnection(localStream) {
     }
   };
 
-  pc2.onremovestream = function (e) {
-    peerVideoEl.stop();
-  };
-
   pc1.oniceconnectionstatechange = function (e) {
-    return console.log('iceConnectionState', pc1.iceConnectionState);
+    return console.log('iceConnectionState', e, pc1.iceConnectionState);
   };
 
   pc1.onnegotiationneeded = function (e) {
+    console.log('negotiatioNneeded', e);
+
     return pc1.createOffer().then(function (d) {
       return pc1.setLocalDescription(d);
     }).then(function () {

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -153,12 +153,14 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 			String(videoViewWidth), String(videoViewHeight), String(visible), String(opacity), String(zIndex),
 			String(mirrored), String(clip), String(borderRadius))
 
-		let videoViewLeft: Double = (elementWidth - videoViewWidth) / 2
-		let videoViewTop: Double = (elementHeight - videoViewHeight) / 2
+		let videoViewLeft: Double = (elementWidth - videoViewWidth) / 2;
+		let videoViewTop: Double = (elementHeight - videoViewHeight) / 2;
+		
+		let screenStatusBarHeight = CGFloat(UIApplication.shared.statusBarFrame.height);
 
 		self.elementView.frame = CGRect(
 			x: CGFloat(elementLeft),
-			y: CGFloat(elementTop),
+			y: screenStatusBarHeight + CGFloat(elementTop),
 			width: CGFloat(elementWidth),
 			height: CGFloat(elementHeight)
 		)
@@ -188,10 +190,10 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		self.elementView.alpha = CGFloat(opacity)
 		self.elementView.layer.zPosition = CGFloat(zIndex)
 
-                // if the zIndex is 0 (the default) bring the view to the top, last one wins
-                if zIndex == 0 {
+		// if the zIndex is 0 (the default) bring the view to the top, last one wins
+		if zIndex == 0 {
 			self.webView.superview?.bringSubviewToFront(self.elementView)
-                }
+		}
 
 		if !mirrored {
 			self.elementView.transform = CGAffineTransform.identity

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -36,7 +36,13 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		self.videoView.isUserInteractionEnabled = false
 
 		// Place the video element view inside the WebView's superview
-		self.webView.superview?.addSubview(self.elementView)
+		if #available(iOS 11.0, *) {
+			self.webView?.scrollView.addSubview(self.elementView)
+		} else {
+			self.webView?.superview?.addSubview(self.elementView)
+		}
+		self.webView?.isOpaque = false
+		self.webView?.backgroundColor = UIColor.clear        
 	}
 
 
@@ -156,11 +162,9 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		let videoViewLeft: Double = (elementWidth - videoViewWidth) / 2;
 		let videoViewTop: Double = (elementHeight - videoViewHeight) / 2;
 		
-		let screenStatusBarHeight = CGFloat(UIApplication.shared.statusBarFrame.height);
-
 		self.elementView.frame = CGRect(
 			x: CGFloat(elementLeft),
-			y: screenStatusBarHeight + CGFloat(elementTop),
+			y: CGFloat(elementTop),
 			width: CGFloat(elementWidth),
 			height: CGFloat(elementHeight)
 		)


### PR DESCRIPTION
add screenStatusBarHeight to elementView.frame.y computation to fix bad position over status-bar when video.style.position.top = 0

Test Script used:
- https://github.com/cordova-rtc/cordova-plugin-iosrtc/blob/master/extra/renderer-and-libwebrtc-tests.js

Before 

![BC18C72A-2327-4BF9-BF18-BF28AAB2B2F1](https://user-images.githubusercontent.com/8635/63087195-d5b25080-bf51-11e9-899f-6f6250c4bcc7.png)


After

![BC18C72A-2327-4BF9-BF18-BF28AAB2B2F4](https://user-images.githubusercontent.com/8635/63086954-46a53880-bf51-11e9-9405-f18647c5da07.png)
