### PR TITLE
fix typo on iosrtcPlugin.swift

### DIFF
--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -854,7 +854,7 @@ class iosrtcPlugin : CDVPlugin {
 	}
 
 
-	@objc(dumo:) func dump(_ command: CDVInvokedUrlCommand) {
+	@objc(dump:) func dump(_ command: CDVInvokedUrlCommand) {
 		NSLog("iosrtcPlugin#dump()")
 
 		for (id, _) in self.pluginRTCPeerConnections {


### PR DESCRIPTION
Simple typo I caught while looking through the changes made for Swift 4.2 support. Thanks for all of the work that went into bringing this project back up to speed.