### PR TITLE
RTCPeerConnection.setLocalDescription() and other  methods which take SDP as input now directly accept an object

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2,8 +2,8 @@
  * cordova-plugin-iosrtc v5.0.0
  * Cordova iOS plugin exposing the full WebRTC W3C JavaScript APIs
  * Copyright 2015-2017 eFace2Face, Inc. (https://eface2face.com)
- * Copyright 2017-2019 BasqueVoIPMafia (https://github.com/BasqueVoIPMafia)
- * Copyright 2019 Cordova-RTC (https://github.com/cordova-rtc)
+ * Copyright 2015-2019 BasqueVoIPMafia (https://github.com/BasqueVoIPMafia)
+ * Copyright 2017-2019 Cordova-RTC (https://github.com/cordova-rtc)
  * License MIT
  */
 
@@ -1550,19 +1550,14 @@ RTCPeerConnection.prototype.setLocalDescription = function (desc) {
 		}
 	}
 
-	debug('setLocalDescription() [desc:%o]', desc);
+	// "This is no longer necessary, however; RTCPeerConnection.setLocalDescription() and other 
+	// methods which take SDP as input now directly accept an object conforming to the RTCSessionDescriptionInit dictionary, 
+	// so you don't have to instantiate an RTCSessionDescription yourself.""
+	// Source: https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/RTCSessionDescription#Example
+	// Still we do instnanciate RTCSessionDescription, so internal object is used properly.
 
 	if (!(desc instanceof RTCSessionDescription)) {
-		if (isPromise) {
-			return new Promise(function (resolve, reject) {
-				reject(new Errors.InvalidSessionDescriptionError('setLocalDescription() must be called with a RTCSessionDescription instance as first argument'));
-			});
-		} else {
-			if (typeof errback === 'function') {
-				errback(new Errors.InvalidSessionDescriptionError('setLocalDescription() must be called with a RTCSessionDescription instance as first argument'));
-			}
-			return;
-		}
+		desc = new RTCSessionDescription(desc);
 	}
 
 	if (isPromise) {
@@ -1643,17 +1638,14 @@ RTCPeerConnection.prototype.setRemoteDescription = function (desc) {
 
 	debug('setRemoteDescription() [desc:%o]', desc);
 
+	// "This is no longer necessary, however; RTCPeerConnection.setLocalDescription() and other 
+	// methods which take SDP as input now directly accept an object conforming to the RTCSessionDescriptionInit dictionary, 
+	// so you don't have to instantiate an RTCSessionDescription yourself.""
+	// Source: https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/RTCSessionDescription#Example
+	// Still we do instnanciate RTCSessionDescription so internal object is used properly.
+
 	if (!(desc instanceof RTCSessionDescription)) {
-		if (isPromise) {
-			return new Promise(function (resolve, reject) {
-				reject(new Errors.InvalidSessionDescriptionError('setRemoteDescription() must be called with a RTCSessionDescription instance as first argument'));
-			});
-		} else {
-			if (typeof errback === 'function') {
-				errback(new Errors.InvalidSessionDescriptionError('setRemoteDescription() must be called with a RTCSessionDescription instance as first argument'));
-			}
-			return;
-		}
+		desc = new RTCSessionDescription(desc);
 	}
 
 	if (isPromise) {

--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -228,19 +228,14 @@ RTCPeerConnection.prototype.setLocalDescription = function (desc) {
 		}
 	}
 
-	debug('setLocalDescription() [desc:%o]', desc);
+	// "This is no longer necessary, however; RTCPeerConnection.setLocalDescription() and other 
+	// methods which take SDP as input now directly accept an object conforming to the RTCSessionDescriptionInit dictionary, 
+	// so you don't have to instantiate an RTCSessionDescription yourself.""
+	// Source: https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/RTCSessionDescription#Example
+	// Still we do instnanciate RTCSessionDescription, so internal object is used properly.
 
 	if (!(desc instanceof RTCSessionDescription)) {
-		if (isPromise) {
-			return new Promise(function (resolve, reject) {
-				reject(new Errors.InvalidSessionDescriptionError('setLocalDescription() must be called with a RTCSessionDescription instance as first argument'));
-			});
-		} else {
-			if (typeof errback === 'function') {
-				errback(new Errors.InvalidSessionDescriptionError('setLocalDescription() must be called with a RTCSessionDescription instance as first argument'));
-			}
-			return;
-		}
+		desc = new RTCSessionDescription(desc);
 	}
 
 	if (isPromise) {
@@ -321,17 +316,14 @@ RTCPeerConnection.prototype.setRemoteDescription = function (desc) {
 
 	debug('setRemoteDescription() [desc:%o]', desc);
 
+	// "This is no longer necessary, however; RTCPeerConnection.setLocalDescription() and other 
+	// methods which take SDP as input now directly accept an object conforming to the RTCSessionDescriptionInit dictionary, 
+	// so you don't have to instantiate an RTCSessionDescription yourself.""
+	// Source: https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/RTCSessionDescription#Example
+	// Still we do instnanciate RTCSessionDescription so internal object is used properly.
+
 	if (!(desc instanceof RTCSessionDescription)) {
-		if (isPromise) {
-			return new Promise(function (resolve, reject) {
-				reject(new Errors.InvalidSessionDescriptionError('setRemoteDescription() must be called with a RTCSessionDescription instance as first argument'));
-			});
-		} else {
-			if (typeof errback === 'function') {
-				errback(new Errors.InvalidSessionDescriptionError('setRemoteDescription() must be called with a RTCSessionDescription instance as first argument'));
-			}
-			return;
-		}
+		desc = new RTCSessionDescription(desc);
 	}
 
 	if (isPromise) {


### PR DESCRIPTION
Note: this is only required if you dont use webrtc-adapter.