### PR TITLE
Recognize when a video receives a new srcObject and re-render it

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2748,6 +2748,16 @@ function observeVideo(video) {
 		if (video.srcObject && !video._iosrtcMediaStreamRendererId) {
 			// If this video element was NOT previously handling a MediaStreamRenderer, release it.
 			handleVideo(video);
+		} else if (video.srcObject && video._iosrtcMediaStreamRendererId) {
+			// The video element has received a new srcObject.
+			var stream = video.srcObject;
+			if (stream && typeof stream.getBlobId === 'function') {
+				var mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
+				var mediaStream = mediaStreams[stream.getBlobId()];
+				if (mediaStreamRenderer && mediaStream) {
+					mediaStreamRenderer.render(mediaStream);
+				}
+			}
 		}
 	});
 

--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2756,7 +2756,7 @@ function observeVideo(video) {
 				releaseMediaStreamRenderer(video);
 				// Install new renderer
 				provideMediaStreamRenderer(video, stream.getBlobId());
-                       }
+			}
 		}
 	});
 

--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2752,12 +2752,11 @@ function observeVideo(video) {
 			// The video element has received a new srcObject.
 			var stream = video.srcObject;
 			if (stream && typeof stream.getBlobId === 'function') {
-				var mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
-				var mediaStream = mediaStreams[stream.getBlobId()];
-				if (mediaStreamRenderer && mediaStream) {
-					mediaStreamRenderer.render(mediaStream);
-				}
-			}
+				// Release previous renderer
+				releaseMediaStreamRenderer(video);
+				// Install new renderer
+				provideMediaStreamRenderer(video, stream.getBlobId());
+                       }
 		}
 	});
 

--- a/js/videoElementsHandler.js
+++ b/js/videoElementsHandler.js
@@ -203,10 +203,10 @@ function observeVideo(video) {
 			handleVideo(video);
 		} else if (video.srcObject && video._iosrtcMediaStreamRendererId) {
 			// The video element has received a new srcObject.
-			const stream = video.srcObject;
+			var stream = video.srcObject;
 			if (stream && typeof stream.getBlobId === 'function') {
-				const mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
-				const mediaStream = mediaStreams[stream.getBlobId()];
+				var mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
+				var mediaStream = mediaStreams[stream.getBlobId()];
 				if (mediaStreamRenderer && mediaStream) {
 					mediaStreamRenderer.render(mediaStream);
 				}

--- a/js/videoElementsHandler.js
+++ b/js/videoElementsHandler.js
@@ -201,6 +201,16 @@ function observeVideo(video) {
 		if (video.srcObject && !video._iosrtcMediaStreamRendererId) {
 			// If this video element was NOT previously handling a MediaStreamRenderer, release it.
 			handleVideo(video);
+		} else if (video.srcObject && video._iosrtcMediaStreamRendererId) {
+			// The video element has received a new srcObject.
+			const stream = video.srcObject;
+			if (stream && typeof stream.getBlobId === 'function') {
+				const mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
+				const mediaStream = mediaStreams[stream.getBlobId()];
+				if (mediaStreamRenderer && mediaStream) {
+					mediaStreamRenderer.render(mediaStream);
+				}
+			}
 		}
 	});
 

--- a/js/videoElementsHandler.js
+++ b/js/videoElementsHandler.js
@@ -209,7 +209,7 @@ function observeVideo(video) {
 				releaseMediaStreamRenderer(video);
 				// Install new renderer
 				provideMediaStreamRenderer(video, stream.getBlobId());
-                       }
+			}
 		}
 	});
 

--- a/js/videoElementsHandler.js
+++ b/js/videoElementsHandler.js
@@ -205,12 +205,11 @@ function observeVideo(video) {
 			// The video element has received a new srcObject.
 			var stream = video.srcObject;
 			if (stream && typeof stream.getBlobId === 'function') {
-				var mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
-				var mediaStream = mediaStreams[stream.getBlobId()];
-				if (mediaStreamRenderer && mediaStream) {
-					mediaStreamRenderer.render(mediaStream);
-				}
-			}
+				// Release previous renderer
+				releaseMediaStreamRenderer(video);
+				// Install new renderer
+				provideMediaStreamRenderer(video, stream.getBlobId());
+                       }
 		}
 	});
 


### PR DESCRIPTION
With the deprecation of the src attribute and not being able to use MutationObserver with srcObject, I noticed that adding a new MediaStream to a video element with a already existing srcObject (and not setting it to null in between) will result in the video displaying only a black square.
So to combat that I added a check for if the video "updated" the srcObject and if so re-renders the MediaStream.