### PR TITLE
Restore Callbacks Support on registerGlobals getUserMedia|enumerateDevices RTCPeerConnection.prototype.createAnswer|createOffer|setRemoteDescription|setLocalDescription|addIceCandidate support for JsSIP, SIP.js and sipML5

### DIFF
--- a/dist/cordova-plugin-iosrtc.js
+++ b/dist/cordova-plugin-iosrtc.js
@@ -2513,8 +2513,57 @@ function refreshVideos() {
 	}
 }
 
+function callbackifyMethod(originalMethod) {
+  	return function () {
+		var success, failure,
+		  originalArgs = Array.prototype.slice.call(arguments);
 
-function registerGlobals() {
+		var callbackArgs = [];
+		originalArgs.forEach(function (arg) {
+		  if (typeof arg === 'function') {
+			if (!success) {
+			  success = arg;
+			} else {
+			  failure = arg;
+			}
+		  } else {
+			callbackArgs.push(arg);
+		  }
+		});
+
+		var promiseResult = originalMethod.apply(this, callbackArgs);
+
+		// Only apply then if callback success available
+		if (typeof success === 'function') {
+			promiseResult = promiseResult.then(success);
+		}
+
+		// Only apply catch if callback failure available
+		if (typeof failure === 'function') {
+			promiseResult = promiseResult.catch(failure);
+		}
+
+		return promiseResult;
+	};
+}
+
+function callbackifyPrototype(proto, method) {
+	var originalMethod = proto[method];
+	proto[method] = callbackifyMethod(originalMethod);
+}
+
+function restoreCallbacksSupport() {
+	debug('restoreCallbacksSupport()');
+	getUserMedia = callbackifyMethod(getUserMedia);
+	enumerateDevices = callbackifyMethod(enumerateDevices);
+	callbackifyPrototype(RTCPeerConnection.prototype, 'createAnswer');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'createOffer');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'setRemoteDescription');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'setLocalDescription');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'addIceCandidate');
+}
+
+function registerGlobals(doNotRestoreCallbacksSupport) {
 	debug('registerGlobals()');
 
 	if (!global.navigator) {
@@ -2529,6 +2578,12 @@ function registerGlobals() {
 	navigator.webkitGetUserMedia            = getUserMedia;
 	navigator.mediaDevices.getUserMedia     = getUserMedia;
 	navigator.mediaDevices.enumerateDevices = enumerateDevices;
+
+	// Restore Callback support
+	if (!doNotRestoreCallbacksSupport) {
+		restoreCallbacksSupport();
+	}
+
 	window.RTCPeerConnection                = RTCPeerConnection;
 	window.webkitRTCPeerConnection          = RTCPeerConnection;
 	window.RTCSessionDescription            = RTCSessionDescription;
@@ -2537,7 +2592,6 @@ function registerGlobals() {
 	window.webkitMediaStream                = MediaStream;
 	window.MediaStreamTrack                 = MediaStreamTrack;
 }
-
 
 function dump() {
 	exec(null, null, 'iosrtcPlugin', 'dump', []);

--- a/js/iosrtc.js
+++ b/js/iosrtc.js
@@ -81,8 +81,57 @@ function refreshVideos() {
 	}
 }
 
+function callbackifyMethod(originalMethod) {
+  	return function () {
+		var success, failure,
+		  originalArgs = Array.prototype.slice.call(arguments);
 
-function registerGlobals() {
+		var callbackArgs = [];
+		originalArgs.forEach(function (arg) {
+		  if (typeof arg === 'function') {
+			if (!success) {
+			  success = arg;
+			} else {
+			  failure = arg;
+			}
+		  } else {
+			callbackArgs.push(arg);
+		  }
+		});
+
+		var promiseResult = originalMethod.apply(this, callbackArgs);
+
+		// Only apply then if callback success available
+		if (typeof success === 'function') {
+			promiseResult = promiseResult.then(success);
+		}
+
+		// Only apply catch if callback failure available
+		if (typeof failure === 'function') {
+			promiseResult = promiseResult.catch(failure);
+		}
+
+		return promiseResult;
+	};
+}
+
+function callbackifyPrototype(proto, method) {
+	var originalMethod = proto[method];
+	proto[method] = callbackifyMethod(originalMethod);
+}
+
+function restoreCallbacksSupport() {
+	debug('restoreCallbacksSupport()');
+	getUserMedia = callbackifyMethod(getUserMedia);
+	enumerateDevices = callbackifyMethod(enumerateDevices);
+	callbackifyPrototype(RTCPeerConnection.prototype, 'createAnswer');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'createOffer');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'setRemoteDescription');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'setLocalDescription');
+	callbackifyPrototype(RTCPeerConnection.prototype, 'addIceCandidate');
+}
+
+function registerGlobals(doNotRestoreCallbacksSupport) {
 	debug('registerGlobals()');
 
 	if (!global.navigator) {
@@ -97,6 +146,12 @@ function registerGlobals() {
 	navigator.webkitGetUserMedia            = getUserMedia;
 	navigator.mediaDevices.getUserMedia     = getUserMedia;
 	navigator.mediaDevices.enumerateDevices = enumerateDevices;
+
+	// Restore Callback support
+	if (!doNotRestoreCallbacksSupport) {
+		restoreCallbacksSupport();
+	}
+
 	window.RTCPeerConnection                = RTCPeerConnection;
 	window.webkitRTCPeerConnection          = RTCPeerConnection;
 	window.RTCSessionDescription            = RTCSessionDescription;
@@ -105,7 +160,6 @@ function registerGlobals() {
 	window.webkitMediaStream                = MediaStream;
 	window.MediaStreamTrack                 = MediaStreamTrack;
 }
-
 
 function dump() {
 	exec(null, null, 'iosrtcPlugin', 'dump', []);


### PR DESCRIPTION
Tested on JsSIP and SIP.js with FreeSWITCH (Sorry sipML5 is too much for me)


<img width="1031" alt="Screen Shot 2019-10-07 at 11 58 13 PM" src="https://user-images.githubusercontent.com/8635/66351696-61e36180-e95e-11e9-978c-52278405e36e.png">

# Testing

To test `task/restore-callbacks-support` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#task/restore-callbacks-support --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save