### PR TITLE
Decode XML entities in project name in iosrtc-swift-support.js hook

### DIFF
--- a/extra/hooks/iosrtc-swift-support.js
+++ b/extra/hooks/iosrtc-swift-support.js
@@ -9,6 +9,7 @@ var
 	fs = require("fs"),
 	path = require("path"),
 	xcode = require('xcode'),
+	xmlEntities = new (require('html-entities').XmlEntities)(),
 
 	IPHONEOS_DEPLOYMENT_TARGET = '10.2',
 	IPHONEOS_DEPLOYMENT_TARGET_XCODE = '"' + IPHONEOS_DEPLOYMENT_TARGET + '"',
@@ -31,7 +32,8 @@ function getProjectName(protoPath) {
 		cordovaConfigPath = path.join(protoPath, 'config.xml'),
 		content = fs.readFileSync(cordovaConfigPath, 'utf-8');
 
-	return /<name>([\s\S]*)<\/name>/mi.exec(content)[1].trim();
+	var name = /<name>([\s\S]*)<\/name>/mi.exec(content)[1].trim();
+	return xmlEntities.decode(name);
 }
 
 // Drops the comments

--- a/package-lock.json
+++ b/package-lock.json
@@ -3421,6 +3421,11 @@
         "lru-cache": "^5.1.1"
       }
     },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "domready": "^1.0.8",
+    "html-entities": "^1.2.1",
     "random-number": "^0.0.7",
     "xcode": "^2.0.0",
     "yaeti": "^1.0.2"


### PR DESCRIPTION
The hook fails to find the correct files/directories when the project name in config.xml contains XML entities like `&amp;` ('&' symbol).