### PR TITLE
Improve speaker settings

### DIFF
--- a/src/PluginRTCAudioController.swift
+++ b/src/PluginRTCAudioController.swift
@@ -122,7 +122,7 @@ class PluginRTCAudioController {
             let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
             try audioSession.setCategory(
                 AVAudioSession.Category.playAndRecord,
-                mode: AVAudioSession.Mode.default,
+                mode: AVAudioSession.Mode.voiceChat,
                 options: .allowBluetooth
             )
             try audioSession.overrideOutputAudioPort(AVAudioSession.PortOverride.speaker)


### PR DESCRIPTION
The speaker cannot be turned on when selecting audiooutputspeaker. I changed the model to voicechat, which improved the following problems.