### PR TITLE
Fixed black video when remote user rejoin

### DIFF
--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1110,9 +1110,9 @@ class iosrtcPlugin : CDVPlugin {
 	fileprivate func saveMediaStream(_ pluginMediaStream: PluginMediaStream) {
 		if self.pluginMediaStreams[pluginMediaStream.id] == nil {
 			self.pluginMediaStreams[pluginMediaStream.id] = pluginMediaStream
-		} else {
+		} /*else {
 			return;
-		}
+		}*/
 
 		// Store its PluginMediaStreamTracks' into the dictionary.
 		for (id, track) in pluginMediaStream.audioTracks {

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1108,11 +1108,12 @@ class iosrtcPlugin : CDVPlugin {
 	}
 
 	fileprivate func saveMediaStream(_ pluginMediaStream: PluginMediaStream) {
-		if self.pluginMediaStreams[pluginMediaStream.id] == nil {
+		/*if self.pluginMediaStreams[pluginMediaStream.id] == nil {
 			self.pluginMediaStreams[pluginMediaStream.id] = pluginMediaStream
-		} /*else {
+		} else {
 			return;
 		}*/
+		self.pluginMediaStreams[pluginMediaStream.id] = pluginMediaStream
 
 		// Store its PluginMediaStreamTracks' into the dictionary.
 		for (id, track) in pluginMediaStream.audioTracks {


### PR DESCRIPTION
Fixed issue #444 

The `MediaStreamTracks` were not stored in the dictionary `pluginMediaStreamTracks`.