### PR TITLE
generate unique PluginMediaStream and PluginMediaStreamTrack, keep original streamId/trackId for internal calls

### DIFF
--- a/src/PluginMediaStream.swift
+++ b/src/PluginMediaStream.swift
@@ -15,9 +15,9 @@ class PluginMediaStream : NSObject {
 	 */
 	init(rtcMediaStream: RTCMediaStream) {
 		NSLog("PluginMediaStream#init()")
-
+		
 		self.rtcMediaStream = rtcMediaStream
-		self.id = rtcMediaStream.streamId
+		self.id = UUID().uuidString;
 
 		for track: RTCMediaStreamTrack in (self.rtcMediaStream.audioTracks as Array<RTCMediaStreamTrack>) {
 			let pluginMediaStreamTrack = PluginMediaStreamTrack(rtcMediaStreamTrack: track, streamId: id)
@@ -38,12 +38,12 @@ class PluginMediaStream : NSObject {
 		NSLog("PluginMediaStream#deinit()")
 		for (id, _) in audioTracks {
 			if(self.eventListenerForRemoveTrack != nil) {
-			self.eventListenerForRemoveTrack!(id)
+				self.eventListenerForRemoveTrack!(id)
 			}
 		}
 		for (id, _) in videoTracks {
 			if(self.eventListenerForRemoveTrack != nil) {
-			self.eventListenerForRemoveTrack!(id)
+				self.eventListenerForRemoveTrack!(id)
 			}
 		}
 	}

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -3,8 +3,7 @@ import AVFoundation
 
 class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 	
-	
-	var uuid: String
+	var id: String
 	var eventListener: (_ data: NSDictionary) -> Void
 	var closed: Bool
 	
@@ -23,7 +22,7 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		NSLog("PluginMediaStreamRenderer#init()")
 		
 		// Open Renderer
-		self.uuid = UUID().uuidString;
+		self.id = UUID().uuidString;
 		self.closed = false
 		
 		// The browser HTML view.

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -17,14 +17,13 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 	var rtcVideoTrack: RTCVideoTrack?
 
 	init(
-		uuid: String,
 		webView: UIView,
 		eventListener: @escaping (_ data: NSDictionary) -> Void
 	) {
 		NSLog("PluginMediaStreamRenderer#init()")
 		
 		// Open Renderer
-		self.uuid = uuid
+		self.uuid = UUID().uuidString;
 		self.closed = false
 		
 		// The browser HTML view.

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -15,7 +15,7 @@ class PluginMediaStreamTrack : NSObject {
 		NSLog("PluginMediaStreamTrack#init()")
 
 		self.rtcMediaStreamTrack = rtcMediaStreamTrack
-		self.id = rtcMediaStreamTrack.trackId
+		self.id = UUID().uuidString;
 		self.kind = rtcMediaStreamTrack.kind
 		self.renders = [:]
 		self.streamId = streamId;
@@ -94,15 +94,15 @@ class PluginMediaStreamTrack : NSObject {
 	}
 
 	func registerRender(render: PluginMediaStreamRenderer) {
-		if let exist = self.renders[render.uuid] {
+		if let exist = self.renders[render.id] {
 			_ = exist
 		} else {
-			self.renders[render.uuid] = render
+			self.renders[render.id] = render
 		}
 	}
 	
 	func unregisterRender(render: PluginMediaStreamRenderer) {
-		self.renders.removeValue(forKey: render.uuid);
+		self.renders.removeValue(forKey: render.id);
 	}
 
 	func stop() {

--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -289,12 +289,13 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		if (IsUnifiedPlan()) {
 			
 			var streamAdded : Bool = false;
+			let streamId = pluginMediaStream.rtcMediaStream.streamId;
 			for (_, pluginMediaTrack) in pluginMediaStream.audioTracks {
-				streamAdded = self.addTrack(pluginMediaTrack, [pluginMediaStream.id]) && streamAdded;
+				streamAdded = self.addTrack(pluginMediaTrack, [streamId]) && streamAdded;
 			}
 			
 			for (_, pluginMediaTrack) in pluginMediaStream.videoTracks {
-				streamAdded = self.addTrack(pluginMediaTrack, [pluginMediaStream.id]) && streamAdded;
+				streamAdded = self.addTrack(pluginMediaTrack, [streamId]) && streamAdded;
 			}
 			
 			return streamAdded;

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -350,15 +350,16 @@ class iosrtcPlugin : CDVPlugin {
 		}
 		
 		if command.argument(at: 2) != nil {
-			let streamId = command.argument(at: 2) as! String
-			let pluginMediaStream = self.pluginMediaStreams[streamId]
+			let id = command.argument(at: 2) as! String
+			let pluginMediaStream = self.pluginMediaStreams[id]
 			
 			if pluginMediaStream == nil {
-				NSLog("iosrtcPlugin#RTCPeerConnection_addTrack() | ERROR: pluginMediaStream with id=%@ does not exist", String(streamId))
+				NSLog("iosrtcPlugin#RTCPeerConnection_addTrack() | ERROR: pluginMediaStream with id=%@ does not exist", String(id))
 				return;
 			}
 			
-			streamIds.append(pluginMediaStream!.id)
+			let streamId = pluginMediaStream!.rtcMediaStream.streamId;
+			streamIds.append(streamId)
 			self.saveMediaStream(pluginMediaStream!)
 		}
 		
@@ -863,7 +864,6 @@ class iosrtcPlugin : CDVPlugin {
 		let id = command.argument(at: 0) as! Int
 
 		let pluginMediaStreamRenderer = PluginMediaStreamRenderer(
-			uuid: UUID().uuidString,
 			webView: self.webView!,
 			eventListener: { (data: NSDictionary) -> Void in
 				let result = CDVPluginResult(
@@ -1111,6 +1111,7 @@ class iosrtcPlugin : CDVPlugin {
 		if self.pluginMediaStreams[pluginMediaStream.id] == nil {
 			self.pluginMediaStreams[pluginMediaStream.id] = pluginMediaStream
 		} else {
+			NSLog("- PluginMediaStreams already exist [id:%@]", String(pluginMediaStream.id))
 			return;
 		}
 


### PR DESCRIPTION
generate unique PluginMediaStream and PluginMediaStreamTrack, keep original streamId/trackId for internal calls

# Testing

To test `task/stream-track-uuid` branch

```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#task/stream-track-uuid --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```