### PR TITLE
Fix removeStream and add real Ids with UUID suffix to PluginMediaStream and PluginMediaStreamTrack

### DIFF
--- a/src/PluginMediaStream.swift
+++ b/src/PluginMediaStream.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class PluginMediaStream : NSObject {
-	
+
 	var rtcMediaStream: RTCMediaStream
 	var id: String
 	var audioTracks: [String : PluginMediaStreamTrack] = [:]
@@ -15,9 +15,9 @@ class PluginMediaStream : NSObject {
 	 */
 	init(rtcMediaStream: RTCMediaStream) {
 		NSLog("PluginMediaStream#init()")
-		
+
 		self.rtcMediaStream = rtcMediaStream
-		self.id = UUID().uuidString;
+		self.id = rtcMediaStream.streamId + "_" + UUID().uuidString;
 
 		for track: RTCMediaStreamTrack in (self.rtcMediaStream.audioTracks as Array<RTCMediaStreamTrack>) {
 			let pluginMediaStreamTrack = PluginMediaStreamTrack(rtcMediaStreamTrack: track, streamId: id)

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -15,7 +15,7 @@ class PluginMediaStreamTrack : NSObject {
 		NSLog("PluginMediaStreamTrack#init()")
 
 		self.rtcMediaStreamTrack = rtcMediaStreamTrack
-		self.id = UUID().uuidString;
+		self.id = rtcMediaStreamTrack.trackId + "_" + UUID().uuidString;
 		self.kind = rtcMediaStreamTrack.kind
 		self.renders = [:]
 		self.streamId = streamId;
@@ -28,7 +28,7 @@ class PluginMediaStreamTrack : NSObject {
 	func run() {
 		NSLog("PluginMediaStreamTrack#run() [kind:%@, id:%@]", String(self.kind), String(self.id))
 	}
-	
+
 	func getReadyState() -> String {
 		switch self.rtcMediaStreamTrack.readyState  {
 		case RTCMediaStreamTrackState.live:
@@ -88,7 +88,7 @@ class PluginMediaStreamTrack : NSObject {
 			}
 		}
 	}
-	
+
 	func switchCamera() {
 		self.rtcMediaStreamTrack.videoCaptureController?.switchCamera()
 	}
@@ -100,7 +100,7 @@ class PluginMediaStreamTrack : NSObject {
 			self.renders[render.id] = render
 		}
 	}
-	
+
 	func unregisterRender(render: PluginMediaStreamRenderer) {
 		self.renders.removeValue(forKey: render.id);
 	}
@@ -109,10 +109,10 @@ class PluginMediaStreamTrack : NSObject {
 		NSLog("PluginMediaStreamTrack#stop() [kind:%@, id:%@]", String(self.kind), String(self.id))
 
 		self.rtcMediaStreamTrack.videoCaptureController?.stopCapture();
-		
+
 		// Let's try setEnabled(false), but it also fails.
 		self.rtcMediaStreamTrack.isEnabled = false
-		
+
 		for (_, render) in self.renders {
 			render.stop()
 		}


### PR DESCRIPTION
- fix PeerConnection removestream to use PluginMediaStream.id instead of RTCMediaStream.streamId
- suffix PluginMediaStreamTrack.id with real PluginMediaStreamTrack.streamId
- fix PeerConnection removestream to use PluginMediaStream.id instead of RTCMediaStream.streamId