### PR TITLE
Missing Event.target value on iosRTC Events

### DIFF
--- a/extra/renderer-and-libwebrtc-tests.js
+++ b/extra/renderer-and-libwebrtc-tests.js
@@ -6,6 +6,7 @@ var cordova = window.cordova;
 // Expose WebRTC Globals
 if (cordova && cordova.plugins && cordova.plugins.iosrtc) {
   cordova.plugins.iosrtc.registerGlobals();
+  //cordova.plugins.iosrtc.debug.disable('*', true);
   //cordova.plugins.iosrtc.debug.enable('*', true);
   cordova.plugins.iosrtc.turnOnSpeaker(true);
   cordova.plugins.iosrtc.requestPermission(true, true, function (result) {
@@ -36,9 +37,11 @@ function TestGetUserMedia() {
     localStream.stop();
 
     // Clear local video element
-    if (localVideoEl.srcObject) {       
+    if (localVideoEl.srcObject) {
       localVideoEl.srcObject = null;
-      appContainer.removeChild(localVideoEl); 
+      if (localVideoEl.parentNode === appContainer) {
+        appContainer.removeChild(localVideoEl);
+      }
     }
   }
 
@@ -76,7 +79,7 @@ function TestGetUserMedia() {
       deviceId: {
         exact: 'com.apple.avfoundation.avcapturedevice.built-in_video:0'
       }
-    }, 
+    },
     audio: {
       exact: 'Built-In Microphone'
     }*/
@@ -95,7 +98,7 @@ function TestGetUserMedia() {
     TestPluginMediaStreamRenderer(localVideoEl);
 
     return localStream;
-   
+
   }).catch(function (err) {
     console.log('getUserMediaError', err, err.stack);
   });
@@ -113,7 +116,7 @@ function TestPluginMediaStreamRenderer(localVideoEl) {
 
   var animateTimer;
   function animateVideo() {
-    
+
     currentPosition.x = currentPosition.x < (window.innerWidth - parseInt(localVideoEl.style.width, 10)) ? currentPosition.x + 1 : 0;
     currentPosition.y = currentPosition.y < (window.innerHeight - parseInt(localVideoEl.style.height, 10)) ? currentPosition.y + 1 : 0;
 
@@ -128,7 +131,7 @@ function TestPluginMediaStreamRenderer(localVideoEl) {
   }
 
   if (useAnimateVideo) {
-    animateTimer = animateVideo(); 
+    animateTimer = animateVideo();
   }
 
   //
@@ -168,7 +171,7 @@ function TestPluginMediaStreamRenderer(localVideoEl) {
 
 //
 // Test RTCPeerConnection
-// 
+//
 
 var peerConnectionConfig = {
     offerToReceiveVideo: true,
@@ -224,18 +227,18 @@ function TestRTCPeerConnection(localStream) {
 
   // Note: Support for Multiple TestRTCPeerConnection calls
   if (peerStream) {
-    
+
     // Close peer Stream if already connected
     peerStream.stop();
 
     // Clear peer video element
     if (peerVideoEl.srcObject) {
       peerVideoEl.srcObject = null;
-      appContainer.removeChild(peerVideoEl); 
+      appContainer.removeChild(peerVideoEl);
     }
 
     // Disconnect peer
-    if (pc1.iceConnectionState === 'completed') {  
+    if (pc1.iceConnectionState === 'completed') {
       pc1.close();
 
       // Current you cannot reuse previous RTCPeerConnection
@@ -250,13 +253,13 @@ function TestRTCPeerConnection(localStream) {
   // Note: Deprecated Test removeStream
   // pc1.removeStream(pc1.getLocalStreams()[0])
 
-  // Note: Chrome Version 77.0.3865.90 (Official Build) still 
+  // Note: Chrome Version 77.0.3865.90 (Official Build) still
   // require to use addStream without webrtc-adapter.
   localStream.getTracks().forEach(function (track) {
     console.log('addTrack', track);
     pc1.addTrack(track);
   });
-  
+
   function onAddIceCandidate(pc, can) {
     console.log('addIceCandidate', pc, can);
     return can && pc.addIceCandidate(can).catch(function (err) {
@@ -267,7 +270,7 @@ function TestRTCPeerConnection(localStream) {
   pc1.addEventListener('icecandidate', function (e) {
     onAddIceCandidate(pc2, e.candidate);
   });
-  
+
   pc2.addEventListener('icecandidate', function (e) {
     onAddIceCandidate(pc1, e.candidate);
   });
@@ -308,7 +311,7 @@ function TestRTCPeerConnection(localStream) {
   pc1.addEventListener('iceconnectionstatechange', function (e) {
     console.log('pc1.iceConnectionState', e, pc1.iceConnectionState);
 
-    if (pc1.iceConnectionState === 'completed') {      
+    if (pc1.iceConnectionState === 'completed') {
       console.log('pc1.getSenders', pc1.getSenders());
       console.log('pc2.getReceivers', pc2.getReceivers());
     }
@@ -381,7 +384,7 @@ function TestRTCPeerConnection(localStream) {
 var canvasEl;
 function TestMediaRenderCatpure(videoEl) {
 
-  if (!canvasEl) {       
+  if (!canvasEl) {
     canvasEl = document.createElement('canvas');
   }
 
@@ -396,10 +399,10 @@ function TestMediaRenderCatpure(videoEl) {
     canvasEl.height = image.height;
     ctx.drawImage(image, 0, 0);
   });
-  videoEl.render.save(function (data) {
+  localVideoEl.render.save(function (data) {
     image.src = "data:image/jpg;base64," + data;
   });
-} 
+}
 
 var testMediaRenderCatpureAnimateFrame;
 function TestMediaRenderCatpureAnimate() {
@@ -445,12 +448,12 @@ if (useWebRTCAdapter && typeof window.adapter === 'undefined') {
     script.addEventListener('load', function () {
       console.log('useWebRTCAdapter.loaded', script.src);
       TestGetUserMedia().then(function (localStream) {
-        TestRTCPeerConnection(localStream); 
+        TestRTCPeerConnection(localStream);
       });
     });
 } else {
   TestGetUserMedia().then(function (localStream) {
-    TestRTCPeerConnection(localStream); 
+    TestRTCPeerConnection(localStream);
   });
 }
 

--- a/js/EventTarget.js
+++ b/js/EventTarget.js
@@ -11,6 +11,16 @@ var EventTarget = function () {
 EventTarget.prototype = Object.create(YaetiEventTarget.prototype);
 EventTarget.prototype.constructor = EventTarget;
 
+EventTarget.prototype.dispatchEvent = function (event) {
+
+	Object.defineProperty(event, 'target', {
+	  value: this,
+	  writable: false
+	});
+
+	YaetiEventTarget.prototype.dispatchEvent.call(this, event);
+};
+
 /**
  * Expose the EventTarget class.
  */


### PR DESCRIPTION
# Capture

<img width="957" alt="Screen Shot 2020-02-17 at 5 03 16 PM" src="https://user-images.githubusercontent.com/8635/74669932-70614580-51a8-11ea-9942-3cb0bcdd9516.png">

# Testing

To test `bugs/EventTarget` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/EventTarget --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```