### PR TITLE
Allowing audio devices change

### DIFF
--- a/src/PluginGetUserMedia.swift
+++ b/src/PluginGetUserMedia.swift
@@ -135,7 +135,15 @@ class PluginGetUserMedia {
 			
 			NSLog("PluginGetUserMedia#call() | chosen audio constraints: %@", audioConstraints)
 			
-			let audioDeviceId = audioConstraints.object(forKey: "deviceId") as? String
+			
+			var audioDeviceId = audioConstraints.object(forKey: "deviceId") as? String
+			if(audioDeviceId == nil && audioConstraints.object(forKey: "deviceId") != nil){
+				let audioId = audioConstraints.object(forKey: "deviceId") as! NSDictionary
+				audioDeviceId = audioId.object(forKey: "exact") as? String
+				if(audioDeviceId == nil){
+					audioDeviceId = audioId.object(forKey: "ideal") as? String
+				}
+			}
 
 			rtcAudioTrack = self.rtcPeerConnectionFactory.audioTrack(withTrackId: UUID().uuidString)
 			rtcMediaStream.addAudioTrack(rtcAudioTrack!)


### PR DESCRIPTION
Hello @hthetiot 

There's a bug changing the audio devices. Any changes we made, doesn't have any effect. 

The problem is that in [getUserMedia.js](https://github.com/cordova-rtc/cordova-plugin-iosrtc/blob/69bb0eaa7ec6022d289d40c311016fce1167c127/js/getUserMedia.js#L407-L431) the audio constraints are passed to the native code (getUserMedia.swift file) as an object but in that swift file they're trying do cast to _**string**_ , always is `nil` and the audio device doesn't change.

This PR fixes that bug.
