### PR TITLE
Handle possible duplicate remote streamId/trackId with janus/kurento/freeswitch or short duplicate name

### DIFF
--- a/src/PluginMediaStream.swift
+++ b/src/PluginMediaStream.swift
@@ -18,9 +18,9 @@ class PluginMediaStream : NSObject {
 
 		self.rtcMediaStream = rtcMediaStream
 
-		// Handle possible duplicate remote streamId with janus name
+		/// Handle possible duplicate remote streamId with janus or short duplicate name
 		// See: https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues/432
-		if (rtcMediaStream.streamId.starts(with: "janus")) {
+		if (rtcMediaStream.streamId.count < 36) {
 			self.id = rtcMediaStream.streamId + "_" + UUID().uuidString;
 		} else {
 			self.id = rtcMediaStream.streamId;

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -16,9 +16,9 @@ class PluginMediaStreamTrack : NSObject {
 
 		self.rtcMediaStreamTrack = rtcMediaStreamTrack
 
-		// Handle possible duplicate remote trackId with janus name
+		// Handle possible duplicate remote trackId with  janus or short duplicate name
 		// See: https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues/432
-		if (rtcMediaStreamTrack.trackId.starts(with: "janus")) {
+		if (rtcMediaStreamTrack.trackId.count < 36) {
 			self.id = rtcMediaStreamTrack.trackId + "_" + UUID().uuidString;
 		} else {
 			self.id = rtcMediaStreamTrack.trackId;


### PR DESCRIPTION
Short term workarround for #480 

# Testing

To test `bugs/MediaUUID` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/MediaUUID --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```