### PR TITLE
Restore Blob only support for iOS 10.x that does not know MediaStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add support for MediaStreamTrack.clone() method #474
 * Add basic RTCRtpTransceiver|RTCRtpSender|RTCRtpReceiver shim #423
 * Fix getReceivers method doesn't return RTCRtpReceiver array #442
+* Fix Blob only support for iOS 10.x that does not know MediaStream #495
 
 #### Version 6.0.11
 * Fix possible duplicate remote streamId/trackId with janus/kurento/freeswitch or short duplicate name #493

--- a/js/EventTarget.js
+++ b/js/EventTarget.js
@@ -11,6 +11,8 @@ var EventTarget = function () {
 EventTarget.prototype = Object.create(YaetiEventTarget.prototype);
 EventTarget.prototype.constructor = EventTarget;
 
+Object.defineProperties(EventTarget.prototype, Object.getOwnPropertyDescriptors(YaetiEventTarget.prototype));
+
 EventTarget.prototype.dispatchEvent = function (event) {
 
 	Object.defineProperty(event, 'target', {

--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -33,6 +33,7 @@ function newMediaStreamId() {
 
 // Save original MediaStream
 var originalMediaStream = window.MediaStream || window.Blob;
+//var originalMediaStream = window.Blob;
 var originalMediaStreamTrack = MediaStreamTrack.originalMediaStreamTrack;
 
 /**
@@ -56,6 +57,9 @@ function MediaStream(arg, id) {
 	// new MediaStream(MediaStreamTrack[]) // tracks
 	// new MediaStream() // empty
 
+	id = id || newMediaStreamId();
+	var blobId = 'MediaStream_' + id;
+
 	// Extend returned MediaTream with custom MediaStream
 	var stream;
 	if (originalMediaStream !== window.Blob) {
@@ -63,7 +67,7 @@ function MediaStream(arg, id) {
 
 	// Fallback on Blob if originalMediaStream is not a MediaStream and Emulate EventTarget
 	} else {
-		stream = new Blob([], {
+		stream = new Blob([blobId], {
 			type: 'stream'
 		});
 
@@ -93,7 +97,7 @@ function MediaStream(arg, id) {
 	stream._videoTracks = {};
 
 	// Store the stream into the dictionary.
-	stream._blobId = 'MediaStream_' + stream.id;
+	stream._blobId = blobId;
 	mediaStreams[stream._blobId] = stream;
 
 	// Convert arg to array of tracks if possible

--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -281,6 +281,8 @@ MediaStream.prototype.addTrack = function (track) {
 	addListenerForTrackEnded.call(this, track);
 
 	exec(null, null, 'iosrtcPlugin', 'MediaStream_addTrack', [this.id, track.id]);
+
+	this.dispatchEvent(new Event('update'));
 };
 
 
@@ -304,6 +306,8 @@ MediaStream.prototype.removeTrack = function (track) {
 	}
 
 	exec(null, null, 'iosrtcPlugin', 'MediaStream_removeTrack', [this.id, track.id]);
+
+	this.dispatchEvent(new Event('update'));
 
 	checkActive.call(this);
 };


### PR DESCRIPTION
See #494

#### Expected behavior

Video to render when MediaStream fallback on Blob

#### Observerd behavior

Video does not render.

#### Steps to reproduce the problem

Run on iOS 10.3.1

#### Platform information

* **Cordova version**:  8.1.2
* **Plugin version**:  6.0.9
* **iOS version**:  10.3.1
* **Xcode version**: 11.4 (11E146)



# Testing

To test `bugs/Blob` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/Blob --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```