### PR TITLE
handle peerConnection onaddtrack with no stream

### DIFF
--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -630,16 +630,23 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		NSLog("PluginRTCPeerConnection | onaddtrack")
 
 		// TODO investigate why no stream sometimes and confirm still the case.
-		let stream = streams.count > 0 ? streams[0] : nil;
-		let pluginMediaStream = getPluginMediaStream(stream: stream);
-		let pluginMediaTrack = PluginMediaStreamTrack(rtcMediaStreamTrack: rtpReceiver.track!)
+	        let pluginMediaTrack = PluginMediaStreamTrack(rtcMediaStreamTrack: rtpReceiver.track!)
 
-		self.eventListener([
-		   "type": "track",
-		   "track": pluginMediaTrack.getJSON(),
-		   "streamId": pluginMediaStream!.id,
-		   "stream": pluginMediaStream!.getJSON()
-		])
+	        if (streams.isEmpty) {
+	            self.eventListener([
+	                "type": "track",
+	                "track": pluginMediaTrack.getJSON(),
+	            ])
+	        } else {
+	            let pluginMediaStream = getPluginMediaStream(stream: streams[0]);
+
+	            self.eventListener([
+	                "type": "track",
+	                "track": pluginMediaTrack.getJSON(),
+	                "streamId": pluginMediaStream!.id,
+	                "stream": pluginMediaStream!.getJSON()
+	            ])
+	        }
 	}
 
 	/** Called when the SignalingState changed. */

--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -630,7 +630,8 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		NSLog("PluginRTCPeerConnection | onaddtrack")
 
 		// TODO investigate why no stream sometimes and confirm still the case.
-		let pluginMediaStream = getPluginMediaStream(stream: streams[0]);
+		let stream = streams.count > 0 ? streams[0] : nil;
+		let pluginMediaStream = getPluginMediaStream(stream: stream);
 		let pluginMediaTrack = PluginMediaStreamTrack(rtcMediaStreamTrack: rtpReceiver.track!)
 
 		self.eventListener([


### PR DESCRIPTION
# Testing

To test `bygs/onaddtrack-no-stream` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bygs/onaddtrack-no-stream --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```

Note: 'bygs' yes typo sorry