### PR TITLE
fix: use video view for correct screencap framing

### DIFF
--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -236,9 +236,9 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 	}
 	
 	func save() -> String {
-		NSLog("PluginMediaStreamRenderer#save()")
-		UIGraphicsBeginImageContextWithOptions(elementView.bounds.size, elementView.isOpaque, 0.0)
-		elementView.drawHierarchy(in: elementView.bounds, afterScreenUpdates: false)
+        NSLog("PluginMediaStreamRenderer#save()")
+        UIGraphicsBeginImageContextWithOptions(videoView.bounds.size, videoView.isOpaque, 0.0)
+        videoView.drawHierarchy(in: videoView.bounds, afterScreenUpdates: false)
 		let snapshotImageFromMyView = UIGraphicsGetImageFromCurrentImageContext()
 		UIGraphicsEndImageContext()
 		let imageData = snapshotImageFromMyView?.jpegData(compressionQuality: 1.0)


### PR DESCRIPTION
The image captured was the dimension of the container element and not the video element. 