### PR TITLE
Fixes issue #576 not found

### DIFF
--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -592,6 +592,9 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 
 			// Let the plugin store it in its dictionary.
 			pluginMediaStreams[currentPluginMediaStream!.id] = currentPluginMediaStream;
+			
+			// Fixes issue #576
+			self.eventListenerForAddStream(currentPluginMediaStream!)
 		}
 
 		return currentPluginMediaStream;
@@ -602,8 +605,6 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		NSLog("PluginRTCPeerConnection | onaddstream")
 
 		let pluginMediaStream = getPluginMediaStream(stream: stream);
-
-		self.eventListenerForAddStream(pluginMediaStream!)
 
 		// Fire the 'addstream' event so the JS will create a new MediaStream.
 		self.eventListener([


### PR DESCRIPTION
This fixes issue #576. I am not sure if any more code should be moved. Basically if the getPluginStream can initialize a new MediaStream then it make sense to add that to the global media stream list that is in the iortcPlugin. So that when the javascript calls setListener on the MediaStreamTrack the track and the stream are available in the collection. Otherwise the call fails and javascript will never be notified of any of the events on the Track and consequently that track will not be displayed.

Risk this could have some other consequences if the PluginMediaStreams added here were never supposed to be added to the global collection.