### PR TITLE
Allow Background Color of video tag to be kept

### DIFF
--- a/js/MediaStreamRenderer.js
+++ b/js/MediaStreamRenderer.js
@@ -162,10 +162,10 @@ MediaStreamRenderer.prototype.refresh = function () {
 	computedStyle = window.getComputedStyle(this.element);
 
 	// get background color
-	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim() });
-	backgroundColorRgba[3] = '0'
-	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')'
-	backgroundColorRgba.length = 3
+	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim(); });
+	backgroundColorRgba[3] = '0';
+	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')';
+	backgroundColorRgba.length = 3;
 
 	// get padding values
 	paddingTop = parseInt(computedStyle.paddingTop) | 0;
@@ -312,7 +312,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 
 	function hash(str) {
 		var hash = 5381,
-		i = str.length;
+			i = str.length;
 
 		while (i) {
 			hash = (hash * 33) ^ str.charCodeAt(--i);
@@ -323,22 +323,22 @@ MediaStreamRenderer.prototype.refresh = function () {
 
 	function nativeRefresh() {
 		var data = {
-			elementLeft: Math.round(elementLeft),
-			elementTop: Math.round(elementTop),
-			elementWidth: Math.round(elementWidth),
-			elementHeight: Math.round(elementHeight),
-			videoViewWidth: Math.round(videoViewWidth),
-			videoViewHeight: Math.round(videoViewHeight),
-			visible: visible,
-			backgroundColor: backgroundColorRgba.join(','),
-			opacity: opacity,
-			zIndex: zIndex,
-			mirrored: mirrored,
-			objectFit: objectFit,
-			clip: clip,
-			borderRadius: borderRadius
-		},
-		newRefreshCached = hash(JSON.stringify(data));
+				elementLeft: Math.round(elementLeft),
+				elementTop: Math.round(elementTop),
+				elementWidth: Math.round(elementWidth),
+				elementHeight: Math.round(elementHeight),
+				videoViewWidth: Math.round(videoViewWidth),
+				videoViewHeight: Math.round(videoViewHeight),
+				visible: visible,
+				backgroundColor: backgroundColorRgba.join(','),
+				opacity: opacity,
+				zIndex: zIndex,
+				mirrored: mirrored,
+				objectFit: objectFit,
+				clip: clip,
+				borderRadius: borderRadius
+			},
+			newRefreshCached = hash(JSON.stringify(data));
 
 		if (newRefreshCached === self.refreshCached) {
 			return;

--- a/js/MediaStreamRenderer.js
+++ b/js/MediaStreamRenderer.js
@@ -156,9 +156,16 @@ MediaStreamRenderer.prototype.refresh = function () {
 		paddingBottom,
 		paddingLeft,
 		paddingRight,
+		backgroundColorRgba,
 		self = this;
 
 	computedStyle = window.getComputedStyle(this.element);
+
+	// get background color
+	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim() });
+	backgroundColorRgba[3] = '0'
+	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')'
+	backgroundColorRgba.length = 3
 
 	// get padding values
 	paddingTop = parseInt(computedStyle.paddingTop) | 0;
@@ -323,6 +330,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 			videoViewWidth: Math.round(videoViewWidth),
 			videoViewHeight: Math.round(videoViewHeight),
 			visible: visible,
+			backgroundColor: backgroundColorRgba.join(','),
 			opacity: opacity,
 			zIndex: zIndex,
 			mirrored: mirrored,

--- a/src/PluginGetUserMedia.swift
+++ b/src/PluginGetUserMedia.swift
@@ -29,7 +29,7 @@ class PluginGetUserMedia {
 		if (constraints.object(forKey: "video") != nil) {
 			videoRequested = true
 		}
-		
+
 		if constraints.object(forKey: "audio") != nil {
 			audioRequested = true
 		}
@@ -77,13 +77,13 @@ class PluginGetUserMedia {
 		rtcMediaStream = self.rtcPeerConnectionFactory.mediaStream(withStreamId: UUID().uuidString)
 
 		if videoRequested {
-			
+
 			NSLog("PluginGetUserMedia#call() | video requested")
 
 			rtcVideoSource = self.rtcPeerConnectionFactory.videoSource()
 
 			rtcVideoTrack = self.rtcPeerConnectionFactory.videoTrack(with: rtcVideoSource!, trackId: UUID().uuidString)
-			
+
 			// Handle legacy plugin instance or video: true
 			var videoConstraints : NSDictionary = [:];
 			if (!(constraints.object(forKey: "video") is Bool)) {
@@ -97,13 +97,13 @@ class PluginGetUserMedia {
 			let videoCapturer: RTCCameraVideoCapturer = RTCCameraVideoCapturer(delegate: rtcVideoSource!)
 			let videoCaptureController: PluginRTCVideoCaptureController = PluginRTCVideoCaptureController(capturer: videoCapturer)
 			rtcVideoTrack!.videoCaptureController = videoCaptureController
-			
+
 			let constraintsSatisfied = videoCaptureController.setConstraints(constraints: videoConstraints)
 			if (!constraintsSatisfied) {
 				errback("constraints not satisfied")
 				return
 			}
-			
+
 			let captureStarted = videoCaptureController.startCapture()
 			if (!captureStarted) {
 				errback("constraints failed")
@@ -122,20 +122,20 @@ class PluginGetUserMedia {
 
 			rtcMediaStream.addVideoTrack(rtcVideoTrack!)
 		}
-		
+
 		if audioRequested == true {
-			
+
 			NSLog("PluginGetUserMedia#call() | audio requested")
-			
+
 			// Handle legacy plugin instance or audio: true
 			var audioConstraints : NSDictionary = [:];
 			if (!(constraints.object(forKey: "audio") is Bool)) {
 			   audioConstraints = constraints.object(forKey: "audio") as! NSDictionary
 			}
-			
+
 			NSLog("PluginGetUserMedia#call() | chosen audio constraints: %@", audioConstraints)
-			
-			
+
+
 			var audioDeviceId = audioConstraints.object(forKey: "deviceId") as? String
 			if(audioDeviceId == nil && audioConstraints.object(forKey: "deviceId") != nil){
 				let audioId = audioConstraints.object(forKey: "deviceId") as! NSDictionary

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -2,336 +2,356 @@ import Foundation
 import AVFoundation
 
 class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
-	
-	var id: String
-	var eventListener: (_ data: NSDictionary) -> Void
-	var closed: Bool
-	
-	var webView: UIView
-	var elementView: UIView
-	var pluginMediaStream: PluginMediaStream?
-	
-	var videoView: RTCEAGLVideoView
-	var rtcAudioTrack: RTCAudioTrack?
-	var rtcVideoTrack: RTCVideoTrack?
 
-	init(
-		webView: UIView,
-		eventListener: @escaping (_ data: NSDictionary) -> Void
-	) {
-		NSLog("PluginMediaStreamRenderer#init()")
-		
-		// Open Renderer
-		self.id = UUID().uuidString;
-		self.closed = false
-		
-		// The browser HTML view.
-		self.webView = webView
-		self.eventListener = eventListener
-		
-		// The video element view.
-		self.elementView = UIView()
-		
-		// The effective video view in which the the video stream is shown.
-		// It's placed over the elementView.
-		self.videoView = RTCEAGLVideoView()
-		self.videoView.isUserInteractionEnabled = false
+    var id: String
+    var eventListener: (_ data: NSDictionary) -> Void
+    var closed: Bool
 
-		self.elementView.isUserInteractionEnabled = false
-		self.elementView.isHidden = true
-		self.elementView.backgroundColor = UIColor.black
-		self.elementView.addSubview(self.videoView)
-		self.elementView.layer.masksToBounds = true
+    var webView: UIView
+    var elementView: UIView
+    var superView: UIView
+    var pluginMediaStream: PluginMediaStream?
 
-		// Place the video element view inside the WebView's superview
-		self.webView.addSubview(self.elementView)
-		self.webView.isOpaque = false
-		self.webView.backgroundColor = UIColor.clear
-		
-		// https://stackoverflow.com/questions/46317061/use-safe-area-layout-programmatically
-		// https://developer.apple.com/documentation/uikit/uiview/2891102-safearealayoutguide
-		// https://developer.apple.com/documentation/uikit/
-		let view = self.elementView;
-		if #available(iOS 11.0, *) {
-			let guide = webView.safeAreaLayoutGuide;
-			view.topAnchor.constraint(equalTo: guide.topAnchor).isActive = true
-			view.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
-			view.leftAnchor.constraint(equalTo: guide.leftAnchor).isActive = true
-			view.rightAnchor.constraint(equalTo: guide.rightAnchor).isActive = true
-		} else {
-			NSLayoutConstraint(item: view, attribute: .top, relatedBy: .equal, toItem: webView, attribute: .top, multiplier: 1.0, constant: 0).isActive = true
-			NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .equal, toItem: webView, attribute: .bottom, multiplier: 1.0, constant: 0).isActive = true
-			NSLayoutConstraint(item: view, attribute: .leading, relatedBy: .equal, toItem: webView, attribute: .leading, multiplier: 1.0, constant: 0).isActive = true
-			NSLayoutConstraint(item: view, attribute: .trailing, relatedBy: .equal, toItem: webView, attribute: .trailing, multiplier: 1.0, constant: 0).isActive = true
-		}
-	}
+    var videoView: RTCEAGLVideoView
+    var rtcAudioTrack: RTCAudioTrack?
+    var rtcVideoTrack: RTCVideoTrack?
 
-	deinit {
-		NSLog("PluginMediaStreamRenderer#deinit()")
-	}
+    init(
+        webView: UIView,
+        eventListener: @escaping (_ data: NSDictionary) -> Void
+    ) {
+        NSLog("PluginMediaStreamRenderer#init()")
 
-	func run() {
-		NSLog("PluginMediaStreamRenderer#run()")
+        // Open Renderer
+        self.id = UUID().uuidString;
+        self.closed = false
 
-		self.videoView.delegate = self
-	}
+        // The browser HTML view.
+        self.webView = webView
+        self.eventListener = eventListener
 
-	func render(_ pluginMediaStream: PluginMediaStream) {
-		NSLog("PluginMediaStreamRenderer#render()")
+        // The video element view.
+        self.elementView = UIView()
 
-		if self.pluginMediaStream != nil {
-			self.reset()
-		}
+        self.superView = UIView()
+        self.superView.isUserInteractionEnabled = false
 
-		self.pluginMediaStream = pluginMediaStream
+        // The effective video view in which the the video stream is shown.
+        // It's placed over the elementView.
+        self.videoView = RTCEAGLVideoView()
+        self.videoView.isUserInteractionEnabled = false
 
-		// Take the first audio track.
-		for (_, track) in pluginMediaStream.audioTracks {
-			self.rtcAudioTrack = track.rtcMediaStreamTrack as? RTCAudioTrack
-			break
-		}
+        self.elementView.isUserInteractionEnabled = false
+        self.elementView.isHidden = true
+        self.elementView.addSubview(self.videoView)
+        self.elementView.layer.masksToBounds = true
 
-		// Take the first video track.
-		var pluginVideoTrack: PluginMediaStreamTrack?
-		for (_, track) in pluginMediaStream.videoTracks {
-			pluginVideoTrack = track
-			self.rtcVideoTrack = track.rtcMediaStreamTrack as? RTCVideoTrack
-			break
-		}
+        // Place the video element view inside the WebView's superview
+        self.webView.addSubview(self.elementView)
+        self.webView.isOpaque = false
+        self.webView.backgroundColor = UIColor.clear
+        self.webView.addSubview(self.superView)
 
-		if self.rtcVideoTrack != nil {
-			self.rtcVideoTrack!.add(self.videoView)
-			pluginVideoTrack?.registerRender(render: self)
-		}
-	}
+        // https://stackoverflow.com/questions/46317061/use-safe-area-layout-programmatically
+        // https://developer.apple.com/documentation/uikit/uiview/2891102-safearealayoutguide
+        // https://developer.apple.com/documentation/uikit/
+        let view = self.elementView;
+        if #available(iOS 11.0, *) {
+            let guide = webView.safeAreaLayoutGuide;
+            view.topAnchor.constraint(equalTo: guide.topAnchor).isActive = true
+            view.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
+            view.leftAnchor.constraint(equalTo: guide.leftAnchor).isActive = true
+            view.rightAnchor.constraint(equalTo: guide.rightAnchor).isActive = true
+        } else {
+            NSLayoutConstraint(item: view, attribute: .top, relatedBy: .equal, toItem: webView, attribute: .top, multiplier: 1.0, constant: 0).isActive = true
+            NSLayoutConstraint(item: view, attribute: .bottom, relatedBy: .equal, toItem: webView, attribute: .bottom, multiplier: 1.0, constant: 0).isActive = true
+            NSLayoutConstraint(item: view, attribute: .leading, relatedBy: .equal, toItem: webView, attribute: .leading, multiplier: 1.0, constant: 0).isActive = true
+            NSLayoutConstraint(item: view, attribute: .trailing, relatedBy: .equal, toItem: webView, attribute: .trailing, multiplier: 1.0, constant: 0).isActive = true
+        }
+    }
 
-	func mediaStreamChanged() {
-		NSLog("PluginMediaStreamRenderer#mediaStreamChanged()")
+    deinit {
+        NSLog("PluginMediaStreamRenderer#deinit()")
+    }
 
-		if self.pluginMediaStream == nil {
-			return
-		}
+    func run() {
+        NSLog("PluginMediaStreamRenderer#run()")
 
-		let oldRtcVideoTrack: RTCVideoTrack? = self.rtcVideoTrack
+        self.videoView.delegate = self
+    }
 
-		self.rtcAudioTrack = nil
-		self.rtcVideoTrack = nil
+    func render(_ pluginMediaStream: PluginMediaStream) {
+        NSLog("PluginMediaStreamRenderer#render()")
 
-		// Take the first audio track.
-		for (_, track) in self.pluginMediaStream!.audioTracks {
-			self.rtcAudioTrack = track.rtcMediaStreamTrack as? RTCAudioTrack
-			break
-		}
+        if self.pluginMediaStream != nil {
+            self.reset()
+        }
 
-		// Take the first video track.
-		for (_, track) in pluginMediaStream!.videoTracks {
-			self.rtcVideoTrack = track.rtcMediaStreamTrack as? RTCVideoTrack
-			break
-		}
+        self.pluginMediaStream = pluginMediaStream
 
-		// If same video track as before do nothing.
-		if oldRtcVideoTrack != nil && self.rtcVideoTrack != nil &&
-			oldRtcVideoTrack!.trackId == self.rtcVideoTrack!.trackId {
-			NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | same video track as before")
-		}
+        // Take the first audio track.
+        for (_, track) in pluginMediaStream.audioTracks {
+            self.rtcAudioTrack = track.rtcMediaStreamTrack as? RTCAudioTrack
+            break
+        }
 
-		// Different video track.
-		else if oldRtcVideoTrack != nil && self.rtcVideoTrack != nil &&
-			oldRtcVideoTrack!.trackId != self.rtcVideoTrack!.trackId {
-			NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | has a new video track")
+        // Take the first video track.
+        var pluginVideoTrack: PluginMediaStreamTrack?
+        for (_, track) in pluginMediaStream.videoTracks {
+            pluginVideoTrack = track
+            self.rtcVideoTrack = track.rtcMediaStreamTrack as? RTCVideoTrack
+            break
+        }
 
-			oldRtcVideoTrack!.remove(self.videoView)
-			self.rtcVideoTrack!.add(self.videoView)
-		}
+        if self.rtcVideoTrack != nil {
+            self.rtcVideoTrack!.add(self.videoView)
+            pluginVideoTrack?.registerRender(render: self)
+        }
+    }
 
-		// Did not have video but now it has.
-		else if oldRtcVideoTrack == nil && self.rtcVideoTrack != nil {
-			NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | video track added")
+    func mediaStreamChanged() {
+        NSLog("PluginMediaStreamRenderer#mediaStreamChanged()")
 
-			self.rtcVideoTrack!.add(self.videoView)
-		}
+        if self.pluginMediaStream == nil {
+            return
+        }
 
-		// Had video but now it has not.
-		else if oldRtcVideoTrack != nil && self.rtcVideoTrack == nil {
-			NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | video track removed")
+        let oldRtcVideoTrack: RTCVideoTrack? = self.rtcVideoTrack
 
-			oldRtcVideoTrack!.remove(self.videoView)
-		}
-	}
+        self.rtcAudioTrack = nil
+        self.rtcVideoTrack = nil
 
-	func refresh(_ data: NSDictionary) {
-		
-		let elementLeft = data.object(forKey: "elementLeft") as? Double ?? 0
-		let elementTop = data.object(forKey: "elementTop") as? Double ?? 0
-		let elementWidth = data.object(forKey: "elementWidth") as? Double ?? 0
-		let elementHeight = data.object(forKey: "elementHeight") as? Double ?? 0
-		var videoViewWidth = data.object(forKey: "videoViewWidth") as? Double ?? 0
-		var videoViewHeight = data.object(forKey: "videoViewHeight") as? Double ?? 0
-		let visible = data.object(forKey: "visible") as? Bool ?? true
-		let opacity = data.object(forKey: "opacity") as? Double ?? 1
-		let zIndex = data.object(forKey: "zIndex") as? Double ?? 0
-		let mirrored = data.object(forKey: "mirrored") as? Bool ?? false
-		let clip = data.object(forKey: "clip") as? Bool ?? true
-		let borderRadius = data.object(forKey: "borderRadius") as? Double ?? 0
+        // Take the first audio track.
+        for (_, track) in self.pluginMediaStream!.audioTracks {
+            self.rtcAudioTrack = track.rtcMediaStreamTrack as? RTCAudioTrack
+            break
+        }
 
-		NSLog("PluginMediaStreamRenderer#refresh() [elementLeft:%@, elementTop:%@, elementWidth:%@, elementHeight:%@, videoViewWidth:%@, videoViewHeight:%@, visible:%@, opacity:%@, zIndex:%@, mirrored:%@, clip:%@, borderRadius:%@]",
-			String(elementLeft), String(elementTop), String(elementWidth), String(elementHeight),
-			String(videoViewWidth), String(videoViewHeight), String(visible), String(opacity), String(zIndex),
-			String(mirrored), String(clip), String(borderRadius))
+        // Take the first video track.
+        for (_, track) in pluginMediaStream!.videoTracks {
+            self.rtcVideoTrack = track.rtcMediaStreamTrack as? RTCVideoTrack
+            break
+        }
 
-		let videoViewLeft: Double = (elementWidth - videoViewWidth) / 2
-		let videoViewTop: Double = (elementHeight - videoViewHeight) / 2
+        // If same video track as before do nothing.
+        if oldRtcVideoTrack != nil && self.rtcVideoTrack != nil &&
+            oldRtcVideoTrack!.trackId == self.rtcVideoTrack!.trackId {
+            NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | same video track as before")
+        }
 
-		self.elementView.frame = CGRect(
-			x: CGFloat(elementLeft),
-			y: CGFloat(elementTop),
-			width: CGFloat(elementWidth),
-			height: CGFloat(elementHeight)
-		)
+        // Different video track.
+        else if oldRtcVideoTrack != nil && self.rtcVideoTrack != nil &&
+            oldRtcVideoTrack!.trackId != self.rtcVideoTrack!.trackId {
+            NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | has a new video track")
 
-		// NOTE: Avoid a zero-size UIView for the video (the library complains).
-		if videoViewWidth == 0 || videoViewHeight == 0 {
-			videoViewWidth = 1
-			videoViewHeight = 1
-			self.videoView.isHidden = true
-		} else {
-			self.videoView.isHidden = false
-		}
+            oldRtcVideoTrack!.remove(self.videoView)
+            self.rtcVideoTrack!.add(self.videoView)
+        }
 
-		self.videoView.frame = CGRect(
-			x: CGFloat(videoViewLeft),
-			y: CGFloat(videoViewTop),
-			width: CGFloat(videoViewWidth),
-			height: CGFloat(videoViewHeight)
-		)
+        // Did not have video but now it has.
+        else if oldRtcVideoTrack == nil && self.rtcVideoTrack != nil {
+            NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | video track added")
 
-		if visible {
-			self.elementView.isHidden = false
-		} else {
-			self.elementView.isHidden = true
-		}
+            self.rtcVideoTrack!.add(self.videoView)
+        }
 
-		self.elementView.alpha = CGFloat(opacity)
-		self.elementView.layer.zPosition = CGFloat(zIndex)
+        // Had video but now it has not.
+        else if oldRtcVideoTrack != nil && self.rtcVideoTrack == nil {
+            NSLog("PluginMediaStreamRenderer#mediaStreamChanged() | video track removed")
 
-		// if the zIndex is 0 (the default) bring the view to the top, last one wins
-		if zIndex == 0 {
-			self.webView.bringSubviewToFront(self.elementView)
-			//self.webView?.bringSubview(toFront: self.elementView)
-		}
+            oldRtcVideoTrack!.remove(self.videoView)
+        }
+    }
 
-		if !mirrored {
-			self.elementView.transform = CGAffineTransform.identity
-		} else {
-			self.elementView.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
-		}
+    func refresh(_ data: NSDictionary) {
 
-		if clip {
-			self.elementView.clipsToBounds = true
-		} else {
-			self.elementView.clipsToBounds = false
-		}
+        let elementLeft = data.object(forKey: "elementLeft") as? Double ?? 0
+        let elementTop = data.object(forKey: "elementTop") as? Double ?? 0
+        let elementWidth = data.object(forKey: "elementWidth") as? Double ?? 0
+        let elementHeight = data.object(forKey: "elementHeight") as? Double ?? 0
+        var videoViewWidth = data.object(forKey: "videoViewWidth") as? Double ?? 0
+        var videoViewHeight = data.object(forKey: "videoViewHeight") as? Double ?? 0
+        let visible = data.object(forKey: "visible") as? Bool ?? true
+        let opacity = data.object(forKey: "opacity") as? Double ?? 1
+        let zIndex = data.object(forKey: "zIndex") as? Double ?? 0
+        let mirrored = data.object(forKey: "mirrored") as? Bool ?? false
+        let clip = data.object(forKey: "clip") as? Bool ?? true
+        let borderRadius = data.object(forKey: "borderRadius") as? Double ?? 0
+        let backgroundColor = data.object(forKey: "backgroundColor") as? String ?? "0,0,0"
 
-		self.elementView.layer.cornerRadius = CGFloat(borderRadius)
-	}
-	
-	func save() -> String {
+        NSLog("PluginMediaStreamRenderer#refresh() [elementLeft:%@, elementTop:%@, elementWidth:%@, elementHeight:%@, videoViewWidth:%@, videoViewHeight:%@, visible:%@, opacity:%@, zIndex:%@, mirrored:%@, clip:%@, borderRadius:%@]",
+            String(elementLeft), String(elementTop), String(elementWidth), String(elementHeight),
+            String(videoViewWidth), String(videoViewHeight), String(visible), String(opacity), String(zIndex),
+            String(mirrored), String(clip), String(borderRadius))
+
+        let videoViewLeft: Double = (elementWidth - videoViewWidth) / 2
+        let videoViewTop: Double = (elementHeight - videoViewHeight) / 2
+
+        self.elementView.frame = CGRect(
+            x: CGFloat(elementLeft),
+            y: CGFloat(elementTop),
+            width: CGFloat(elementWidth),
+            height: CGFloat(elementHeight)
+        )
+
+        // NOTE: Avoid a zero-size UIView for the video (the library complains).
+        if videoViewWidth == 0 || videoViewHeight == 0 {
+            videoViewWidth = 1
+            videoViewHeight = 1
+            self.videoView.isHidden = true
+        } else {
+            self.videoView.isHidden = false
+        }
+
+        self.videoView.frame = CGRect(
+            x: CGFloat(videoViewLeft),
+            y: CGFloat(videoViewTop),
+            width: CGFloat(videoViewWidth),
+            height: CGFloat(videoViewHeight)
+        )
+
+        if visible {
+            self.elementView.isHidden = false
+        } else {
+            self.elementView.isHidden = true
+        }
+
+        self.elementView.alpha = CGFloat(opacity)
+        self.elementView.layer.zPosition = CGFloat(zIndex)
+
+        // if the zIndex is 0 (the default) bring the view to the top, last one wins
+        if zIndex == 0 {
+            self.webView.bringSubviewToFront(self.elementView)
+            //self.webView?.bringSubview(toFront: self.elementView)
+        }
+
+        if !mirrored {
+            self.elementView.transform = CGAffineTransform.identity
+        } else {
+            self.elementView.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
+        }
+
+        if clip {
+            self.elementView.clipsToBounds = true
+        } else {
+            self.elementView.clipsToBounds = false
+        }
+
+        self.elementView.layer.cornerRadius = CGFloat(borderRadius)
+
+        func UIColorFromHex(rgbValue:UInt32, alpha:Double=1.0)->UIColor {
+            let red = CGFloat((rgbValue & 0xFF0000) >> 16)/256.0
+            let green = CGFloat((rgbValue & 0xFF00) >> 8)/256.0
+            let blue = CGFloat(rgbValue & 0xFF)/256.0
+            return UIColor(red:red, green:green, blue:blue, alpha:CGFloat(alpha))
+        }
+
+        self.superView.frame = self.webView.frame
+        let rgb = backgroundColor.components(separatedBy: ",").map{ CGFloat(($0 as NSString).floatValue) / 256.0 }
+        let color = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
+        self.elementView.backgroundColor = color
+        self.superView.backgroundColor = color
+        self.superView.layer.zPosition = ([self.webView.layer.zPosition, self.elementView.layer.zPosition].min() ?? 0) - 1
+    }
+
+    func save() -> String {
         NSLog("PluginMediaStreamRenderer#save()")
         UIGraphicsBeginImageContextWithOptions(videoView.bounds.size, videoView.isOpaque, 0.0)
         videoView.drawHierarchy(in: videoView.bounds, afterScreenUpdates: false)
-		let snapshotImageFromMyView = UIGraphicsGetImageFromCurrentImageContext()
-		UIGraphicsEndImageContext()
-		let imageData = snapshotImageFromMyView?.jpegData(compressionQuality: 1.0)
-		let strBase64 = imageData?.base64EncodedString(options: .lineLength64Characters)
-		return strBase64!;
-	}
-	
-	func stop() {
-		NSLog("PluginMediaStreamRenderer | video stop")
-		
-		self.eventListener([
-			"type": "videostop"
-		])
-	}
+        let snapshotImageFromMyView = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        let imageData = snapshotImageFromMyView?.jpegData(compressionQuality: 1.0)
+        let strBase64 = imageData?.base64EncodedString(options: .lineLength64Characters)
+        return strBase64!;
+    }
 
-	func close() {
-		NSLog("PluginMediaStreamRenderer#close()")
-		self.closed = true
-		self.reset()
-		self.elementView.removeFromSuperview()
-	}
+    func stop() {
+        NSLog("PluginMediaStreamRenderer | video stop")
 
-	/**
-	 * Private API.
-	 */
-	
-	fileprivate func reset() {
-		NSLog("PluginMediaStreamRenderer#reset()")
+        self.eventListener([
+            "type": "videostop"
+        ])
+    }
 
-		if self.rtcVideoTrack != nil {
-			self.rtcVideoTrack!.remove(self.videoView)
-		}
+    func close() {
+        NSLog("PluginMediaStreamRenderer#close()")
+        self.closed = true
+        self.reset()
+        self.elementView.removeFromSuperview()
+        self.superView.removeFromSuperview()
+    }
 
-		self.pluginMediaStream = nil
-		self.rtcAudioTrack = nil
-		self.rtcVideoTrack = nil
-	}
+    /**
+     * Private API.
+     */
 
-	/**
-	 * Methods inherited from RTCEAGLVideoViewDelegate.
-	 */
-	
-	func videoView(_ videoView: RTCVideoRenderer, didChangeVideoSize size: CGSize) {
-	
-		NSLog("PluginMediaStreamRenderer | video size changed [width:%@, height:%@]",
-			String(describing: size.width), String(describing: size.height))
+    fileprivate func reset() {
+        NSLog("PluginMediaStreamRenderer#reset()")
 
-		self.eventListener([
-			"type": "videoresize",
-			"size": [
-				"width": Int(size.width),
-				"height": Int(size.height)
-			]
-		])
-	}
-	
-	func videoView(_ videoView: RTCVideoRenderer, didChange frame: RTCVideoFrame?) {
-		
-		// TODO save from frame buffer instead of renderer
-		/*
-		let i420: RTCI420BufferProtocol = frame!.buffer.toI420()
-		let YPtr: UnsafePointer<UInt8> = i420.dataY
-		let UPtr: UnsafePointer<UInt8> = i420.dataU
-		let VPtr: UnsafePointer<UInt8> = i420.dataV
-		let YSize: Int = Int(frame!.width * frame!.height)
-		let USize: Int = Int(YSize / 4)
-		let VSize: Int = Int(YSize / 4)
-		var frameSize:Int32 = Int32(YSize + USize + VSize)
-		var width: Int16 = Int16(frame!.width)
-		var height: Int16 = Int16(frame!.height)
-		var rotation: Int16 = Int16(frame!.rotation.rawValue)
-		var timestamp: Int32 = Int32(frame!.timeStamp)
-		
-		// head + body
-		// head: type(2B)+len(4B)+width(2B)+height(2B)+rotation(2B)+timestamp(4B)
-		// body: data(len)
-		let headSize:Int32 = 16
-		let dataSize:Int32 = headSize + frameSize
-		let pduData: NSMutableData? = NSMutableData(length: Int(dataSize))
-		
-		let headPtr = pduData!.mutableBytes
-		var pduType:UInt16 = 0x2401
-		memcpy(headPtr, &pduType, 2)
-		memcpy(headPtr+2, &frameSize, 4)
-		memcpy(headPtr+2+4, &width, 2)
-		memcpy(headPtr+2+4+2, &height, 2)
-		memcpy(headPtr+2+4+2+2, &rotation, 2)
-		//memcpy(headPtr+2+4+2+2+2, &timestamp, 4)
-		
-		let bodyPtr = pduData!.mutableBytes + Int(headSize)
-		memcpy(bodyPtr, YPtr, YSize)
-		memcpy(bodyPtr + YSize, UPtr, USize);
-		memcpy(bodyPtr + YSize + USize, VPtr, VSize);
-		*/
-	}
+        if self.rtcVideoTrack != nil {
+            self.rtcVideoTrack!.remove(self.videoView)
+        }
+
+        self.pluginMediaStream = nil
+        self.rtcAudioTrack = nil
+        self.rtcVideoTrack = nil
+    }
+
+    /**
+     * Methods inherited from RTCEAGLVideoViewDelegate.
+     */
+
+    func videoView(_ videoView: RTCVideoRenderer, didChangeVideoSize size: CGSize) {
+
+        NSLog("PluginMediaStreamRenderer | video size changed [width:%@, height:%@]",
+            String(describing: size.width), String(describing: size.height))
+
+        self.eventListener([
+            "type": "videoresize",
+            "size": [
+                "width": Int(size.width),
+                "height": Int(size.height)
+            ]
+        ])
+    }
+
+    func videoView(_ videoView: RTCVideoRenderer, didChange frame: RTCVideoFrame?) {
+
+        // TODO save from frame buffer instead of renderer
+        /*
+        let i420: RTCI420BufferProtocol = frame!.buffer.toI420()
+        let YPtr: UnsafePointer<UInt8> = i420.dataY
+        let UPtr: UnsafePointer<UInt8> = i420.dataU
+        let VPtr: UnsafePointer<UInt8> = i420.dataV
+        let YSize: Int = Int(frame!.width * frame!.height)
+        let USize: Int = Int(YSize / 4)
+        let VSize: Int = Int(YSize / 4)
+        var frameSize:Int32 = Int32(YSize + USize + VSize)
+        var width: Int16 = Int16(frame!.width)
+        var height: Int16 = Int16(frame!.height)
+        var rotation: Int16 = Int16(frame!.rotation.rawValue)
+        var timestamp: Int32 = Int32(frame!.timeStamp)
+
+        // head + body
+        // head: type(2B)+len(4B)+width(2B)+height(2B)+rotation(2B)+timestamp(4B)
+        // body: data(len)
+        let headSize:Int32 = 16
+        let dataSize:Int32 = headSize + frameSize
+        let pduData: NSMutableData? = NSMutableData(length: Int(dataSize))
+
+        let headPtr = pduData!.mutableBytes
+        var pduType:UInt16 = 0x2401
+        memcpy(headPtr, &pduType, 2)
+        memcpy(headPtr+2, &frameSize, 4)
+        memcpy(headPtr+2+4, &width, 2)
+        memcpy(headPtr+2+4+2, &height, 2)
+        memcpy(headPtr+2+4+2+2, &rotation, 2)
+        //memcpy(headPtr+2+4+2+2+2, &timestamp, 4)
+
+        let bodyPtr = pduData!.mutableBytes + Int(headSize)
+        memcpy(bodyPtr, YPtr, YSize)
+        memcpy(bodyPtr + YSize, UPtr, USize);
+        memcpy(bodyPtr + YSize + USize, VPtr, VSize);
+        */
+    }
 }

--- a/src/PluginRTCDTMFSender.swift
+++ b/src/PluginRTCDTMFSender.swift
@@ -17,7 +17,7 @@ class PluginRTCDTMFSender : NSObject {
 		NSLog("PluginRTCDTMFSender#init()")
 
 		self.eventListener = eventListener
-		
+
 		// TODO check if new rtcRtpSender can be used one Unified-Plan merged
 		//let streamIds = [streamId]
 		//self.rtcRtpSender = rtcPeerConnection.add(track, streamIds: streamIds);

--- a/src/PluginRTCDataChannel.swift
+++ b/src/PluginRTCDataChannel.swift
@@ -188,7 +188,7 @@ class PluginRTCDataChannel : NSObject, RTCDataChannelDelegate {
 
 		self.rtcDataChannel!.close()
 	}
-	
+
 	static func stateToString(state: RTCDataChannelState) -> String {
 		switch state {
 		case RTCDataChannelState.connecting:

--- a/src/PluginRTCPeerConnectionConfig.swift
+++ b/src/PluginRTCPeerConnectionConfig.swift
@@ -2,35 +2,35 @@ import Foundation
 
 
 class PluginRTCPeerConnectionConfig {
-	
+
 	fileprivate let allowedSdpSemantics = [
 		"plan-b": RTCSdpSemantics.planB,
 		"unified-plan": RTCSdpSemantics.unifiedPlan
 	]
-  
+
 	fileprivate let allowedBundlePolicy = [
 		"balanced": RTCBundlePolicy.balanced,
 		"max-compat": RTCBundlePolicy.maxCompat,
 		"max-bundle": RTCBundlePolicy.maxBundle
 	]
-	
+
 	fileprivate let allowedIceTransportPolicy = [
 		"all": RTCIceTransportPolicy.all,
 		"relay": RTCIceTransportPolicy.relay
 	]
-	
+
 	fileprivate let allowedRtcpMuxPolicy = [
 		"require": RTCRtcpMuxPolicy.require,
 		"negotiate": RTCRtcpMuxPolicy.negotiate,
 	]
-	
+
 	fileprivate var rtcConfiguration: RTCConfiguration
 
 	init(pcConfig: NSDictionary?) {
 		NSLog("PluginRTCPeerConnectionConfig#init()")
-		
+
 		self.rtcConfiguration = RTCConfiguration()
-			
+
 		/*
 		 Since Chrome 65, this has been an experimental feature that you can opt-in to by passing
 		 sdpSemantics:'unified-plan' to the RTCPeerConnection constructor, with transceivers added in M69.
@@ -38,28 +38,28 @@ class PluginRTCPeerConnectionConfig {
 		 The target is to release Unified Plan by default in 72 Stable. For more information, see https://webrtc.org/web-apis/chrome/unified-plan/.
 		 See: https://www.chromestatus.com/feature/5723303167655936
 		*/
-		
+
 		let sdpSemanticsConfig = pcConfig?.object(forKey: "sdpSemantics") as? String;
 		let sdpSemantics = (sdpSemanticsConfig != nil && allowedSdpSemantics[sdpSemanticsConfig!] != nil) ?
 			allowedSdpSemantics[sdpSemanticsConfig!] : RTCSdpSemantics.unifiedPlan
-		
+
 		rtcConfiguration.sdpSemantics = sdpSemantics!;
-		
+
 		/*
 		 Specifies how to handle negotiation of candidates when the remote peer is not compatible with the SDP BUNDLE standard.
 		 This must be one of the values from the enum RTCBundlePolicy. If this value isn't included in the dictionary, "balanced" is assumed.
-		 
+
 		 "balanced"    On BUNDLE-aware connections, the ICE agent should gather candidates for all of the media types in use (audio, video, and data). Otherwise, the ICE agent should only negotiate one audio and video track on separate transports.
 		 "max-compat"    The ICE agent should gather candidates for each track, using separate transports to negotiate all media tracks for connections which aren't BUNDLE-compatible.
 		 "max-bundle"    The ICE agent should gather candidates for just one track. If the connection isn't BUNDLE-compatible, then the ICE agent should negotiate just one media track.
 		 */
-		
+
 		let bundlePolicyConfig = pcConfig?.object(forKey: "bundlePolicy") as? String;
 		let bundlePolicy = (bundlePolicyConfig != nil && allowedBundlePolicy[bundlePolicyConfig!] != nil) ?
 								allowedBundlePolicy[bundlePolicyConfig!] : RTCBundlePolicy.balanced
-		
+
 		rtcConfiguration.bundlePolicy = bundlePolicy!;
-		
+
 		/*
 		 An Array of objects of type RTCCertificate which are used by the connection for authentication.
 		 If this property isn't specified, a set of certificates is generated automatically for each RTCPeerConnection instance.
@@ -69,7 +69,7 @@ class PluginRTCPeerConnectionConfig {
 		  this property is ignored in future calls to RTCPeerConnection.setConfiguration().
 		 */
 		// TODO certificates
-		
+
 		/*
 		 An unsigned 16-bit integer value which specifies the size of the prefetched ICE candidate pool.
 		 The default value is 0 (meaning no candidate prefetching will occur).
@@ -78,25 +78,25 @@ class PluginRTCPeerConnectionConfig {
 		 for inspection when RTCPeerConnection.setLocalDescription() is called.
 		 Changing the size of the ICE candidate pool may trigger the beginning of ICE gathering.
 		 */
-		
+
 		let iceCandidatePoolSizeConfig = pcConfig?.object(forKey: "iceCandidatePoolSize") as? Int32;
 		rtcConfiguration.iceCandidatePoolSize = iceCandidatePoolSizeConfig != nil ? iceCandidatePoolSizeConfig! : 0;
-		
+
 		/*
 		 The current ICE transport policy; this must be one of the values from the RTCIceTransportPolicy enum.
 		 If this isn't specified, "all" is assumed.
-		
+
 		 - "all"    All ICE candidates will be considered.
 		 - "public"    Only ICE candidates with public IP addresses will be considered. Removed from the specification's May 13, 2016 working draft
 		 - "relay"     Only ICE candidates whose IP addresses are being relayed, such as those being passed through a TURN server, will be considered.
 		 */
-		
+
 		let iceTransportPolicyConfig = pcConfig?.object(forKey: "iceTransportPolicy") as? String;
 		let iceTransportPolicy = (iceTransportPolicyConfig != nil && allowedIceTransportPolicy[iceTransportPolicyConfig!] != nil) ?
 									allowedIceTransportPolicy[iceTransportPolicyConfig!] : RTCIceTransportPolicy.all
-		
+
 		rtcConfiguration.iceTransportPolicy = iceTransportPolicy!;
-		
+
 		/*
 		 The RTCP mux policy to use when gathering ICE candidates, in order to support non-multiplexed RTCP.
 		 The value must be one of those from the RTCRtcpMuxPolicy enum. The default is "require".
@@ -106,13 +106,13 @@ class PluginRTCPeerConnectionConfig {
 		 - "require"    Tells the ICE agent to gather ICE candidates for only RTP, and to multiplex RTCP atop them.
 						 If the remote peer doesn't support RTCP multiplexing, then session negotiation fails.
 		 */
-		
+
 		let rtcpMuxPolicyConfig = pcConfig?.object(forKey: "rtcpMuxPolicy") as? String;
 		let rtcpMuxPolicy = (rtcpMuxPolicyConfig != nil && allowedRtcpMuxPolicy[rtcpMuxPolicyConfig!] != nil) ?
 								allowedRtcpMuxPolicy[rtcpMuxPolicyConfig!] : RTCRtcpMuxPolicy.require
-		
+
 		rtcConfiguration.rtcpMuxPolicy = rtcpMuxPolicy!;
-		
+
 		/*
 		 A DOMString which specifies the target peer identity for the RTCPeerConnection.
 		 If this value is set (it defaults to null), the RTCPeerConnection will not connect to a remote peer
@@ -131,7 +131,7 @@ class PluginRTCPeerConnectionConfig {
 			for iceServer: NSDictionary in iceServers! {
 				let urlsConfig = (iceServer.object(forKey: "url") != nil ?
 						iceServer.object(forKey: "url") : iceServer.object(forKey: "urls"))
-				
+
 				let urls = urlsConfig is String ? [urlsConfig as? String ?? ""] : urlsConfig as? [String] ?? nil;
 				let username = iceServer.object(forKey: "username") as? String ?? ""
 				let password = iceServer.object(forKey: "credential") as? String ?? ""
@@ -153,10 +153,10 @@ class PluginRTCPeerConnectionConfig {
 	deinit {
 		NSLog("PluginRTCPeerConnectionConfig#deinit()")
 	}
-	
+
 	func getConfiguration() -> RTCConfiguration {
 		NSLog("PluginRTCPeerConnectionConfig#getConfiguration()")
-		
+
 		return self.rtcConfiguration
 	}
 }

--- a/src/PluginRTCPeerConnectionConstraints.swift
+++ b/src/PluginRTCPeerConnectionConstraints.swift
@@ -8,24 +8,24 @@ class PluginRTCPeerConnectionConstraints {
 		NSLog("PluginRTCPeerConnectionConstraints#init()")
 		var mandatoryConstraints: [String : String] = [:]
 		var optionalConstraints: [String : String] = [:]
-		
+
 		// Handle constraints at the root of pcConstraints.mandatory
 		let _mandatoryConstraints = pcConstraints?.object(forKey: "mandatory") as? NSDictionary
 		if _mandatoryConstraints != nil {
 			mandatoryConstraints = PluginRTCPeerConnectionConstraints.parseConstraints(constraints: _mandatoryConstraints!)
 		}
-		
+
 		// Handle constraints at the root of pcConstraints.optional
 		let _optionalConstraints = pcConstraints?.object(forKey: "optional") as? NSArray
 		if _optionalConstraints != nil {
 			optionalConstraints = PluginRTCPeerConnectionConstraints.parseOptionalConstraints(optionalConstraints: _optionalConstraints!)
 		}
-		
+
 		// Handle constraints at the root of pcConstraints
 		if pcConstraints != nil && _optionalConstraints == nil && _mandatoryConstraints == nil  {
 			mandatoryConstraints = PluginRTCPeerConnectionConstraints.parseConstraints(constraints: pcConstraints!)
 		}
-		
+
 		NSLog("PluginRTCPeerConnectionConstraints#init() | [mandatoryConstraints:%@, optionalConstraints:%@]",
 			mandatoryConstraints, optionalConstraints)
 
@@ -34,7 +34,7 @@ class PluginRTCPeerConnectionConstraints {
 			optionalConstraints: optionalConstraints
 		)
 	}
-	
+
 	// Custom proprietary constrains in libwebrtc
 	fileprivate static let allowedOptionalConstraints : Array = [
 		// Temporary pseudo-constraints used to enable DTLS-SRT
@@ -55,15 +55,15 @@ class PluginRTCPeerConnectionConstraints {
 		"googSuspendBelowMinBitrate",
 		//"googScreencastMinBitrate"
 	]
-	
+
 	fileprivate static func parseOptionalConstraints(optionalConstraints: NSArray) -> [String : String] {
 		var _constraints : [String : String] = [:]
-		
+
 		for optionalConstraint in optionalConstraints {
 			if (optionalConstraint is NSDictionary) {
 				for (key, value) in optionalConstraint as! NSDictionary {
 					let finalKey: String = key as! String;
-					
+
 					// Parse only allowedOptionalConstraints
 					if (allowedOptionalConstraints.firstIndex(of: finalKey) != nil) {
 					   if value is Int32 {
@@ -77,10 +77,10 @@ class PluginRTCPeerConnectionConstraints {
 				}
 			}
 		}
-		
+
 		return _constraints;
 	}
-	
+
 	// https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer#RTCOfferOptions_dictionary
 	// TODO TODO voiceActivityDetection This option defaults to true
 	fileprivate static let allowedConstraints : Array = [
@@ -89,14 +89,14 @@ class PluginRTCPeerConnectionConstraints {
 		"OfferToReceiveAudio",
 		"voiceActivityDetection"
 	]
-	
+
 	fileprivate static func parseConstraints(constraints: NSDictionary) -> [String : String] {
 		var _constraints : [String : String] = [:]
-		
+
 		for (key, value) in constraints {
 			var finalValue: String,
 				finalKey: String = key as! String;
-			
+
 			if value is Bool {
 				finalValue = value as! Bool ? "true" : "false"
 			} else if value is String {
@@ -104,7 +104,7 @@ class PluginRTCPeerConnectionConstraints {
 			} else {
 				continue
 			}
-			
+
 			// Handle Spec for offerToReceiveAudio|offerToReceiveVideo but
 			// libwebrtc still use OfferToReceiveAudio|OfferToReceiveVideo
 			if (finalKey == "offerToReceiveAudio") {
@@ -114,16 +114,16 @@ class PluginRTCPeerConnectionConstraints {
 			} else if (finalKey == "iceRestart") {
 				finalKey =  "IceRestart";
 			}
-			
+
 			// Filter to avoid injection
 			if (allowedConstraints.firstIndex(of: finalKey) != nil) {
 				_constraints[finalKey] = finalValue
 			}
 		}
-		
+
 		return _constraints;
 	}
-	
+
 	deinit {
 		NSLog("PluginRTCPeerConnectionConstraints#deinit()")
 	}

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -853,9 +853,16 @@ MediaStreamRenderer.prototype.refresh = function () {
 		paddingBottom,
 		paddingLeft,
 		paddingRight,
+		backgroundColorRgba,
 		self = this;
 
 	computedStyle = window.getComputedStyle(this.element);
+
+	// get background color
+	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim() });
+	backgroundColorRgba[3] = '0'
+	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')'
+	backgroundColorRgba.length = 3
 
 	// get padding values
 	paddingTop = parseInt(computedStyle.paddingTop) | 0;
@@ -1020,6 +1027,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 			videoViewWidth: Math.round(videoViewWidth),
 			videoViewHeight: Math.round(videoViewHeight),
 			visible: visible,
+			backgroundColor: backgroundColorRgba.join(','),
 			opacity: opacity,
 			zIndex: zIndex,
 			mirrored: mirrored,


### PR DESCRIPTION
This adds a new subview to the webView which we ensure is always behind the webView and video views.
In the refresh cycle it updates the background color, setting the alpha channel to 0 on the HTML video.
And the Element View and new "super view" background colors to the passed rgb value.

The UIView functions as a new layer for color behind the (likely transparent) WebView.


Probably a breaking change if this gets merged since people might have a css property that gets picked up and used now.