### PR TITLE
feat: use background-color from video element css

### DIFF
--- a/js/MediaStreamRenderer.js
+++ b/js/MediaStreamRenderer.js
@@ -156,9 +156,16 @@ MediaStreamRenderer.prototype.refresh = function () {
 		paddingBottom,
 		paddingLeft,
 		paddingRight,
+		backgroundColorRgba,
 		self = this;
 
 	computedStyle = window.getComputedStyle(this.element);
+
+	// get background color
+	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim(); });
+	backgroundColorRgba[3] = '0';
+	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')';
+	backgroundColorRgba.length = 3;
 
 	// get padding values
 	paddingTop = parseInt(computedStyle.paddingTop) | 0;
@@ -323,6 +330,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 			videoViewWidth: Math.round(videoViewWidth),
 			videoViewHeight: Math.round(videoViewHeight),
 			visible: visible,
+			backgroundColor: backgroundColorRgba.join(','),
 			opacity: opacity,
 			zIndex: zIndex,
 			mirrored: mirrored,

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -9,6 +9,7 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 	
 	var webView: UIView
 	var elementView: UIView
+	var superView: UIView
 	var pluginMediaStream: PluginMediaStream?
 	
 	var videoView: RTCEAGLVideoView
@@ -31,7 +32,11 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		
 		// The video element view.
 		self.elementView = UIView()
-		
+
+		self.superView = UIView()
+		self.superView.isUserInteractionEnabled = false
+		self.superView.backgroundColor = UIColor.black
+
 		// The effective video view in which the the video stream is shown.
 		// It's placed over the elementView.
 		self.videoView = RTCEAGLVideoView()
@@ -47,7 +52,8 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		self.webView.addSubview(self.elementView)
 		self.webView.isOpaque = false
 		self.webView.backgroundColor = UIColor.clear
-		
+		self.webView.addSubview(self.superView)
+
 		// https://stackoverflow.com/questions/46317061/use-safe-area-layout-programmatically
 		// https://developer.apple.com/documentation/uikit/uiview/2891102-safearealayoutguide
 		// https://developer.apple.com/documentation/uikit/
@@ -173,6 +179,7 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		let mirrored = data.object(forKey: "mirrored") as? Bool ?? false
 		let clip = data.object(forKey: "clip") as? Bool ?? true
 		let borderRadius = data.object(forKey: "borderRadius") as? Double ?? 0
+		let backgroundColor = data.object(forKey: "backgroundColor") as? String ?? "0,0,0"
 
 		NSLog("PluginMediaStreamRenderer#refresh() [elementLeft:%@, elementTop:%@, elementWidth:%@, elementHeight:%@, videoViewWidth:%@, videoViewHeight:%@, visible:%@, opacity:%@, zIndex:%@, mirrored:%@, clip:%@, borderRadius:%@]",
 			String(elementLeft), String(elementTop), String(elementWidth), String(elementHeight),
@@ -233,6 +240,13 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		}
 
 		self.elementView.layer.cornerRadius = CGFloat(borderRadius)
+
+		self.superView.frame = self.webView.frame
+		let rgb = backgroundColor.components(separatedBy: ",").map{ CGFloat(($0 as NSString).floatValue) / 256.0 }
+		let color = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
+		self.elementView.backgroundColor = color
+		self.superView.backgroundColor = color
+		self.superView.layer.zPosition = ([self.webView.layer.zPosition, self.elementView.layer.zPosition].min() ?? 0) - 1
 	}
 	
 	func save() -> String {
@@ -259,6 +273,7 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		self.closed = true
 		self.reset()
 		self.elementView.removeFromSuperview()
+		self.superView.removeFromSuperview()
 	}
 
 	/**

--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -9,7 +9,6 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 	
 	var webView: UIView
 	var elementView: UIView
-	var superView: UIView
 	var pluginMediaStream: PluginMediaStream?
 	
 	var videoView: RTCEAGLVideoView
@@ -33,10 +32,6 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		// The video element view.
 		self.elementView = UIView()
 
-		self.superView = UIView()
-		self.superView.isUserInteractionEnabled = false
-		self.superView.backgroundColor = UIColor.black
-
 		// The effective video view in which the the video stream is shown.
 		// It's placed over the elementView.
 		self.videoView = RTCEAGLVideoView()
@@ -52,7 +47,6 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		self.webView.addSubview(self.elementView)
 		self.webView.isOpaque = false
 		self.webView.backgroundColor = UIColor.clear
-		self.webView.addSubview(self.superView)
 
 		// https://stackoverflow.com/questions/46317061/use-safe-area-layout-programmatically
 		// https://developer.apple.com/documentation/uikit/uiview/2891102-safearealayoutguide
@@ -240,13 +234,9 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		}
 
 		self.elementView.layer.cornerRadius = CGFloat(borderRadius)
-
-		self.superView.frame = self.webView.frame
 		let rgb = backgroundColor.components(separatedBy: ",").map{ CGFloat(($0 as NSString).floatValue) / 256.0 }
 		let color = UIColor(red: rgb[0], green: rgb[1], blue: rgb[2], alpha: 1)
 		self.elementView.backgroundColor = color
-		self.superView.backgroundColor = color
-		self.superView.layer.zPosition = ([self.webView.layer.zPosition, self.elementView.layer.zPosition].min() ?? 0) - 1
 	}
 	
 	func save() -> String {
@@ -273,7 +263,6 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		self.closed = true
 		self.reset()
 		self.elementView.removeFromSuperview()
-		self.superView.removeFromSuperview()
 	}
 
 	/**

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -858,9 +858,16 @@ MediaStreamRenderer.prototype.refresh = function () {
 		paddingBottom,
 		paddingLeft,
 		paddingRight,
+		backgroundColorRgba,
 		self = this;
 
 	computedStyle = window.getComputedStyle(this.element);
+
+	// get background color
+	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim(); });
+	backgroundColorRgba[3] = '0';
+	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')';
+	backgroundColorRgba.length = 3;
 
 	// get padding values
 	paddingTop = parseInt(computedStyle.paddingTop) | 0;
@@ -1025,6 +1032,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 			videoViewWidth: Math.round(videoViewWidth),
 			videoViewHeight: Math.round(videoViewHeight),
 			visible: visible,
+			backgroundColor: backgroundColorRgba.join(','),
 			opacity: opacity,
 			zIndex: zIndex,
 			mirrored: mirrored,


### PR DESCRIPTION
reopening due to #580 being closed

~This adds a new subview to the webView which we ensure is always behind the webView and video views.~
In the refresh cycle it updates the background color, setting the alpha channel to 0 on the HTML video
and the Element View and element background color to the passed rgb value.
