### PR TITLE
fix: ensure proper orientation for first launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /TODO
 /NO_GIT/
 .DS_Store
+.idea

--- a/src/PluginGetUserMedia.swift
+++ b/src/PluginGetUserMedia.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import UIKit.UIDevice
 
 class PluginGetUserMedia {
 
@@ -8,10 +9,12 @@ class PluginGetUserMedia {
 	init(rtcPeerConnectionFactory: RTCPeerConnectionFactory) {
 		NSLog("PluginGetUserMedia#init()")
 		self.rtcPeerConnectionFactory = rtcPeerConnectionFactory
+		UIDevice.current.beginGeneratingDeviceOrientationNotifications()
 	}
 
 	deinit {
 		NSLog("PluginGetUserMedia#deinit()")
+		UIDevice.current.endGeneratingDeviceOrientationNotifications()
 	}
 
 	func call(


### PR DESCRIPTION
When a cordova app is initially launched from XCode using this plugin and the device is in landscape orientation, the first video stream will have the wrong orientation.  I was able to recreate this issue using the sample app.  Let me know if there is a more appropriate `init`/`deinit` in which to place these calls, but get user media seemed appropriate to me.

## Before
![image](https://user-images.githubusercontent.com/3026298/97466411-4f88ec80-1900-11eb-9c9c-c5fc19f62a63.png)

## After
![image](https://user-images.githubusercontent.com/3026298/97466521-6e877e80-1900-11eb-9155-6b24d68a3758.png)
