### PR TITLE
Prettier for JS styling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{*rc,json}]
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,11 @@
 {
+  "extends": [
+    "plugin:prettier/recommended"
+  ],
+  "ignorePatterns": ["www/**/*.js"],
+  "env": {
+    "es6": true
+  },
   "rules": {
     "indent": [
       2,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-	"bitwise": false,
+  "bitwise": false,
 	"curly": true,
 	"eqeqeq": true,
 	"forin": true,
@@ -26,8 +26,9 @@
 	"node": true,
 	"shelljs": false,
 	"worker": false,
+  "esversion": 6,
 
-	"globals": {
+  "globals": {
 		"Promise": false
 	}
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
 	"maxdepth": 4,
 	"maxstatements": false,
 	"maxlen": 210,
+	"laxbreak": true,
 
 	"browser": true,
 	"browserify": true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"printWidth": 100
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,8 @@ script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export REPO_SLUG=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_REPO_SLUG; else echo $TRAVIS_PULL_REQUEST_SLUG; fi)
   # Lint and Build plugin
-  - "gulp"
+  - "npm run lint"
+  - "gulp browserify"
   # Test Plugin platform build with ionic
   - "ionic start myApp blank; cd myApp;"
   - "ionic cordova platform add $CORDOVA_PLATFORM@latest --verbose"

--- a/extra/hooks/iosrtc-swift-support.js
+++ b/extra/hooks/iosrtc-swift-support.js
@@ -5,12 +5,10 @@
 // This hook automates this:
 // https://github.com/cordova-rtc/cordova-plugin-iosrtc/blob/master/docs/Building.md
 
-var
-	fs = require("fs"),
-	path = require("path"),
+var fs = require('fs'),
+	path = require('path'),
 	xcode = require('xcode'),
 	xmlEntities = new (require('html-entities').XmlEntities)(),
-
 	DISABLE_IOSRTC_HOOK = process.env.DISABLE_IOSRTC_HOOK ? true : false,
 	IPHONEOS_DEPLOYMENT_TARGET = process.env.IPHONEOS_DEPLOYMENT_TARGET || '10.2',
 	IPHONEOS_DEPLOYMENT_TARGET_XCODE = '"' + IPHONEOS_DEPLOYMENT_TARGET + '"',
@@ -21,7 +19,7 @@ var
 	ENABLE_BITCODE = 'NO',
 	ENABLE_BITCODE_XCODE = '"' + ENABLE_BITCODE + '"',
 	UNIFIED_BRIDGING_HEADER = 'Plugins/Unified-Bridging-Header.h',
-	IOSRTC_BRIDGING_HEADER = "cordova-plugin-iosrtc-Bridging-Header.h",
+	IOSRTC_BRIDGING_HEADER = 'cordova-plugin-iosrtc-Bridging-Header.h',
 	BRIDGING_HEADER_END = '/Plugins/cordova-plugin-iosrtc/' + IOSRTC_BRIDGING_HEADER,
 	TEST_UNIFIED_BRIDGING_HEADER = process.env.TEST_UNIFIED_BRIDGING_HEADER ? true : false; // Set to true to test handling of existing swift bridging header
 
@@ -29,11 +27,10 @@ var
 
 // Returns the project name
 function getProjectName(protoPath) {
-	var
-		cordovaConfigPath = path.join(protoPath, 'config.xml'),
+	var cordovaConfigPath = path.join(protoPath, 'config.xml'),
 		content = fs.readFileSync(cordovaConfigPath, 'utf-8');
 
-	var name = /<name>([ \S]*)<\/name>/mi.exec(content)[1].trim();
+	var name = /<name>([ \S]*)<\/name>/im.exec(content)[1].trim();
 
 	return xmlEntities.decode(name);
 }
@@ -41,8 +38,7 @@ function getProjectName(protoPath) {
 // Drops the comments
 var COMMENT_KEY = /_comment$/;
 function nonComments(obj) {
-	var
-		keys = Object.keys(obj),
+	var keys = Object.keys(obj),
 		newObj = {},
 		i = 0;
 
@@ -60,11 +56,14 @@ function matchBuildSettingsValue(value, expectedValue) {
 }
 
 function hasBuildSettingsValue(value, expectedValue) {
-	return value && (matchBuildSettingsValue(value, expectedValue) || value.indexOf(expectedValue) !== -1);
+	return (
+		value &&
+		(matchBuildSettingsValue(value, expectedValue) || value.indexOf(expectedValue) !== -1)
+	);
 }
 
 function convertToFloat(value) {
-	return parseFloat(value.replace(/[^\d.-]/g,''), 10);
+	return parseFloat(value.replace(/[^\d.-]/g, ''), 10);
 }
 
 function matchMinValue(value, minValue) {
@@ -73,13 +72,18 @@ function matchMinValue(value, minValue) {
 }
 
 function matchBuildSettingsMinValue(value, expectedValue) {
-	return value && (matchBuildSettingsValue(value, expectedValue) || matchMinValue(value, expectedValue));
+	return (
+		value &&
+		(matchBuildSettingsValue(value, expectedValue) || matchMinValue(value, expectedValue))
+	);
 }
 
 function matchXcconfigPathValue(swiftOptions, path, expectedValue) {
-	return swiftOptions.filter(function (swiftOption) {
-		return swiftOption === path + ' = ' + expectedValue;
-	}).length > 0;
+	return (
+		swiftOptions.filter(function (swiftOption) {
+			return swiftOption === path + ' = ' + expectedValue;
+		}).length > 0
+	);
 }
 
 function getXcconfigPathValue(swiftOptions, path) {
@@ -103,7 +107,7 @@ function getRelativeToProjectRootPath(path, projectRoot) {
 }
 
 function readFileLines(filePath) {
-	return fs.readFileSync(filePath).toString().split("\n");
+	return fs.readFileSync(filePath).toString().split('\n');
 }
 
 function debug(msg) {
@@ -118,7 +122,6 @@ function debugError(msg) {
 // Starting here
 
 module.exports = function (context) {
-
 	// This script has to be executed depending on the command line arguments, not
 	// on the hook execution cycle.
 	/*
@@ -132,8 +135,7 @@ module.exports = function (context) {
 		return;
 	}
 
-	var
-		projectRoot = context.opts.projectRoot,
+	var projectRoot = context.opts.projectRoot,
 		projectName = getProjectName(projectRoot),
 		platformPath = path.join(projectRoot, 'platforms', 'ios'),
 		platformProjectPath = path.join(platformPath, projectName),
@@ -147,7 +149,10 @@ module.exports = function (context) {
 
 	// Showing info about the tasks to do
 	debug('cordova-plugin-iosrtc hook is checking issues in the generated project files:');
-	debug('- Minimum "iOS Deployment Target" and "Deployment Target" to: ' + IPHONEOS_DEPLOYMENT_TARGET_XCODE);
+	debug(
+		'- Minimum "iOS Deployment Target" and "Deployment Target" to: ' +
+			IPHONEOS_DEPLOYMENT_TARGET_XCODE
+	);
 	debug('- "Runpath Search Paths" to: ' + RUNPATH_SEARCH_PATHS_XCODE);
 	if (TEST_UNIFIED_BRIDGING_HEADER) {
 		debug('- "Objective-C Bridging Header" to: ' + UNIFIED_BRIDGING_HEADER);
@@ -159,18 +164,25 @@ module.exports = function (context) {
 
 	// Checking if the project files are in the right place
 	if (!fs.existsSync(xcodeProjectConfigPath)) {
-		debugError('an error occurred searching the project file at: "' + xcodeProjectConfigPath + '"');
+		debugError(
+			'an error occurred searching the project file at: "' + xcodeProjectConfigPath + '"'
+		);
 
 		return;
 	}
-	debug('".pbxproj" project file found: ' + getRelativeToProjectRootPath(xcodeProjectConfigPath, projectRoot));
+	debug(
+		'".pbxproj" project file found: ' +
+			getRelativeToProjectRootPath(xcodeProjectConfigPath, projectRoot)
+	);
 
 	if (!fs.existsSync(xcconfigPath)) {
 		debugError('an error occurred searching the project file at: "' + xcconfigPath + '"');
 
 		return;
 	}
-	debug('".xcconfig" project file found: ' + getRelativeToProjectRootPath(xcconfigPath, projectRoot));
+	debug(
+		'".xcconfig" project file found: ' + getRelativeToProjectRootPath(xcconfigPath, projectRoot)
+	);
 
 	xcodeProject = xcode.project(xcodeProjectConfigPath);
 
@@ -186,12 +198,24 @@ module.exports = function (context) {
 		currentSwiftOptions = readFileLines(xcconfigPath);
 	}
 
-	if (!matchXcconfigPathValue(currentSwiftOptions, 'LD_RUNPATH_SEARCH_PATHS', RUNPATH_SEARCH_PATHS)) {
+	if (
+		!matchXcconfigPathValue(
+			currentSwiftOptions,
+			'LD_RUNPATH_SEARCH_PATHS',
+			RUNPATH_SEARCH_PATHS
+		)
+	) {
 		swiftOptions.push('LD_RUNPATH_SEARCH_PATHS = ' + RUNPATH_SEARCH_PATHS);
 		xcconfigPathChanged = true;
 	}
 
-	if (!matchXcconfigMinValue(currentSwiftOptions, 'IPHONEOS_DEPLOYMENT_TARGET', IPHONEOS_DEPLOYMENT_TARGET)) {
+	if (
+		!matchXcconfigMinValue(
+			currentSwiftOptions,
+			'IPHONEOS_DEPLOYMENT_TARGET',
+			IPHONEOS_DEPLOYMENT_TARGET
+		)
+	) {
 		swiftOptions.push('IPHONEOS_DEPLOYMENT_TARGET = ' + IPHONEOS_DEPLOYMENT_TARGET);
 		xcconfigPathChanged = true;
 	}
@@ -210,13 +234,25 @@ module.exports = function (context) {
 	if (TEST_UNIFIED_BRIDGING_HEADER) {
 		existingSwiftBridgingHeaderPath = path.join(platformProjectPath, UNIFIED_BRIDGING_HEADER);
 	} else {
-		if (!matchXcconfigPathValue(currentSwiftOptions, 'SWIFT_OBJC_BRIDGING_HEADER', swiftBridgingHeaderPath)) {
-			var currentSwiftBridgingHeader = getXcconfigPathValue(currentSwiftOptions, 'SWIFT_OBJC_BRIDGING_HEADER').replace('$(PROJECT_DIR)/$(PROJECT_NAME)/', '');
+		if (
+			!matchXcconfigPathValue(
+				currentSwiftOptions,
+				'SWIFT_OBJC_BRIDGING_HEADER',
+				swiftBridgingHeaderPath
+			)
+		) {
+			var currentSwiftBridgingHeader = getXcconfigPathValue(
+				currentSwiftOptions,
+				'SWIFT_OBJC_BRIDGING_HEADER'
+			).replace('$(PROJECT_DIR)/$(PROJECT_NAME)/', '');
 			if (!existingSwiftBridgingHeaderPath) {
 				swiftOptions.push('SWIFT_OBJC_BRIDGING_HEADER = ' + swiftBridgingHeaderPath);
 				xcconfigPathChanged = true;
 			} else {
-				existingSwiftBridgingHeaderPath = path.join(platformProjectPath, currentSwiftBridgingHeader);
+				existingSwiftBridgingHeaderPath = path.join(
+					platformProjectPath,
+					currentSwiftBridgingHeader
+				);
 			}
 		}
 	}
@@ -236,9 +272,11 @@ module.exports = function (context) {
 
 	// Parsing it
 	xcodeProject.parse(function (error) {
-
 		if (error) {
-			debugError('an error occurred during the parsing of the project file: ' + xcodeProjectConfigPath);
+			debugError(
+				'an error occurred during the parsing of the project file: ' +
+					xcodeProjectConfigPath
+			);
 
 			return;
 		}
@@ -248,7 +286,6 @@ module.exports = function (context) {
 		var hasSwiftBridgingHeaderPathXcodes = [];
 		var configurations = nonComments(xcodeProject.pbxXCBuildConfigurationSection());
 		Object.keys(configurations).forEach(function (config) {
-
 			var configuration = configurations[config],
 				buildSettings = configuration.buildSettings;
 
@@ -257,12 +294,22 @@ module.exports = function (context) {
 				return;
 			}
 
-			if (!hasBuildSettingsValue(buildSettings.LD_RUNPATH_SEARCH_PATHS, RUNPATH_SEARCH_PATHS_XCODE)) {
+			if (
+				!hasBuildSettingsValue(
+					buildSettings.LD_RUNPATH_SEARCH_PATHS,
+					RUNPATH_SEARCH_PATHS_XCODE
+				)
+			) {
 				buildSettings.LD_RUNPATH_SEARCH_PATHS = RUNPATH_SEARCH_PATHS_XCODE;
 				buildSettingsChanged = true;
 			}
 
-			if (!matchBuildSettingsMinValue(buildSettings.IPHONEOS_DEPLOYMENT_TARGET, IPHONEOS_DEPLOYMENT_TARGET_XCODE)) {
+			if (
+				!matchBuildSettingsMinValue(
+					buildSettings.IPHONEOS_DEPLOYMENT_TARGET,
+					IPHONEOS_DEPLOYMENT_TARGET_XCODE
+				)
+			) {
 				buildSettings.IPHONEOS_DEPLOYMENT_TARGET = IPHONEOS_DEPLOYMENT_TARGET_XCODE;
 				buildSettingsChanged = true;
 			}
@@ -282,48 +329,87 @@ module.exports = function (context) {
 				xcodeProject.addHeaderFile(UNIFIED_BRIDGING_HEADER);
 			}
 
-			if (!hasBuildSettingsValue(buildSettings.SWIFT_OBJC_BRIDGING_HEADER, swiftBridgingHeaderPathXcode)) {
-
+			if (
+				!hasBuildSettingsValue(
+					buildSettings.SWIFT_OBJC_BRIDGING_HEADER,
+					swiftBridgingHeaderPathXcode
+				)
+			) {
 				// Play nice with existing Swift Bridging Header value
 				if (existingSwiftBridgingHeaderPath) {
-
 					// Sync SWIFT_OBJC_BRIDGING_HEADER with existingSwiftBridgingHeaderPath if do not match
-					var existingSwiftBridgingHeaderPathXcode = '"' + existingSwiftBridgingHeaderPath + '"';
-					if (buildSettings.SWIFT_OBJC_BRIDGING_HEADER !== existingSwiftBridgingHeaderPathXcode) {
+					var existingSwiftBridgingHeaderPathXcode =
+						'"' + existingSwiftBridgingHeaderPath + '"';
+					if (
+						buildSettings.SWIFT_OBJC_BRIDGING_HEADER !==
+						existingSwiftBridgingHeaderPathXcode
+					) {
 						buildSettings.SWIFT_OBJC_BRIDGING_HEADER = existingSwiftBridgingHeaderPathXcode;
 						buildSettingsChanged = true;
 					}
 
-					if (hasSwiftBridgingHeaderPathXcodes.indexOf(existingSwiftBridgingHeaderPath) === -1) {
-
+					if (
+						hasSwiftBridgingHeaderPathXcodes.indexOf(
+							existingSwiftBridgingHeaderPath
+						) === -1
+					) {
 						// Check if existing existingSwiftBridgingHeaderPath exists and get file lines
 
-						debug('checking file: ' + getRelativeToProjectRootPath(existingSwiftBridgingHeaderPath, projectRoot));
+						debug(
+							'checking file: ' +
+								getRelativeToProjectRootPath(
+									existingSwiftBridgingHeaderPath,
+									projectRoot
+								)
+						);
 
 						var existingSwiftBridgingHeaderFileLines = [];
 						if (fs.existsSync(existingSwiftBridgingHeaderPath)) {
-							existingSwiftBridgingHeaderFileLines = readFileLines(existingSwiftBridgingHeaderPath);
+							existingSwiftBridgingHeaderFileLines = readFileLines(
+								existingSwiftBridgingHeaderPath
+							);
 						}
 
 						// Check if existing existingSwiftBridgingHeaderFileLines contains swiftBridgingHeaderPath
 						var swiftBridgingHeaderImport = '#import "' + IOSRTC_BRIDGING_HEADER + '"';
-						var hasSwiftBridgingHeaderPathXcode = existingSwiftBridgingHeaderFileLines.filter(function (line) {
-							return line === swiftBridgingHeaderImport;
-						}).length > 0;
+						var hasSwiftBridgingHeaderPathXcode =
+							existingSwiftBridgingHeaderFileLines.filter(function (line) {
+								return line === swiftBridgingHeaderImport;
+							}).length > 0;
 
 						if (!hasSwiftBridgingHeaderPathXcode) {
-							debug('updating existing swift bridging header file: ' + getRelativeToProjectRootPath(existingSwiftBridgingHeaderPath, projectRoot));
+							debug(
+								'updating existing swift bridging header file: ' +
+									getRelativeToProjectRootPath(
+										existingSwiftBridgingHeaderPath,
+										projectRoot
+									)
+							);
 							existingSwiftBridgingHeaderFileLines.push(swiftBridgingHeaderImport);
-							fs.writeFileSync(existingSwiftBridgingHeaderPath, existingSwiftBridgingHeaderFileLines.join('\n'), 'utf-8');
-							debug('file correctly fixed: ' + getRelativeToProjectRootPath(existingSwiftBridgingHeaderPath, projectRoot));
+							fs.writeFileSync(
+								existingSwiftBridgingHeaderPath,
+								existingSwiftBridgingHeaderFileLines.join('\n'),
+								'utf-8'
+							);
+							debug(
+								'file correctly fixed: ' +
+									getRelativeToProjectRootPath(
+										existingSwiftBridgingHeaderPath,
+										projectRoot
+									)
+							);
 						} else {
-							debug('file is correct: ' + getRelativeToProjectRootPath(existingSwiftBridgingHeaderPath, projectRoot));
+							debug(
+								'file is correct: ' +
+									getRelativeToProjectRootPath(
+										existingSwiftBridgingHeaderPath,
+										projectRoot
+									)
+							);
 						}
 
 						hasSwiftBridgingHeaderPathXcodes.push(existingSwiftBridgingHeaderPath);
 					}
-
-
 				} else {
 					buildSettings.SWIFT_OBJC_BRIDGING_HEADER = swiftBridgingHeaderPathXcode;
 					buildSettingsChanged = true;
@@ -334,9 +420,15 @@ module.exports = function (context) {
 		// Writing the file only if changed
 		if (buildSettingsChanged) {
 			fs.writeFileSync(xcodeProjectConfigPath, xcodeProject.writeSync(), 'utf-8');
-			debug('file correctly fixed: ' + getRelativeToProjectRootPath(xcodeProjectConfigPath, projectRoot));
+			debug(
+				'file correctly fixed: ' +
+					getRelativeToProjectRootPath(xcodeProjectConfigPath, projectRoot)
+			);
 		} else {
-			debug('file is correct: ' + getRelativeToProjectRootPath(xcodeProjectConfigPath, projectRoot));
+			debug(
+				'file is correct: ' +
+					getRelativeToProjectRootPath(xcodeProjectConfigPath, projectRoot)
+			);
 		}
 	});
 };

--- a/extra/ios-websocket-hack.js
+++ b/extra/ios-websocket-hack.js
@@ -15,7 +15,6 @@
  * deteriorates the WebSocket performance.
  */
 
-
 (function () {
 	// run on iOS Cordova only
 	if (!(window.cordova && window.cordova.platformId === 'ios')) {
@@ -29,15 +28,12 @@
 	window.WebSocket = FakeWebSocket;
 	window.NativeWebSocket = NativeWebSocket;
 
-
 	// Fake WebSocket class that ill override the native one.
 	function FakeWebSocket() {
-		var
-			self = this,
+		var self = this,
 			url = arguments[0],
 			protocols = arguments[1],
 			listeners = {};
-
 
 		// WebSocket is an EventTarget as per W3C spec.
 
@@ -87,13 +83,13 @@
 		};
 
 		this.dispatchEvent = function (event) {
-			var
-				self = this,
+			var self = this,
 				type,
 				listenersType,
 				dummyListener,
 				stopImmediatePropagation = false,
-				i, listener;
+				i,
+				listener;
 
 			if (!(event instanceof Event)) {
 				throw new Error('first argument must be an instance of Event');
@@ -101,7 +97,7 @@
 
 			type = event.type;
 
-			listenersType = (listeners[type] || []);
+			listenersType = listeners[type] || [];
 
 			dummyListener = this['on' + type];
 			if (typeof dummyListener === 'function') {
@@ -163,7 +159,6 @@
 			};
 		});
 	}
-
 
 	// Expose W3C WebSocket attributes and setters.
 
@@ -250,7 +245,6 @@
 			}
 		}
 	});
-
 
 	// Expose W3C WebSocket methods.
 

--- a/extra/ios_arch.js
+++ b/extra/ios_arch.js
@@ -15,7 +15,7 @@ const ARCH_TYPES = ['i386', 'x86_64', 'armv7', 'arm64'];
  *    `node ios_arch.js --extract`
  * Step 2. re-package binary without simulator archs
  *    `node ios_arch.js --device`
- * 
+ *
  * That's it!
  * Remember to delete generated/backed up files (WebRTC-*) from step 1 if needed
  *
@@ -28,32 +28,32 @@ const ARCH_TYPES = ['i386', 'x86_64', 'armv7', 'arm64'];
 // TODO: consider add a handy option to extract/package/delete automatically
 
 if (process.argv[2] === '--extract' || process.argv[2] === '-e') {
-  console.log('Extracting...');
-  // extract all archs, you might want to delete it later.
-  ARCH_TYPES.forEach(elm => {
-    exec(`lipo -extract ${elm} WebRTC -o WebRTC-${elm}`, {cwd: WEBRTC_BIN_PATH});
-  });
-  exec('cp WebRTC WebRTC-all', {cwd: WEBRTC_BIN_PATH}); // make a backup
+	console.log('Extracting...');
+	// extract all archs, you might want to delete it later.
+	ARCH_TYPES.forEach((elm) => {
+		exec(`lipo -extract ${elm} WebRTC -o WebRTC-${elm}`, { cwd: WEBRTC_BIN_PATH });
+	});
+	exec('cp WebRTC WebRTC-all', { cwd: WEBRTC_BIN_PATH }); // make a backup
 } else if (process.argv[2] === '--simulator' || process.argv[2] === '-s') {
-  // re-package simulator related archs only. ( i386, x86_64 )
-  console.log('Compiling simulator...');
-  exec(`lipo -o WebRTC -create WebRTC-x86_64 WebRTC-i386`, {cwd: WEBRTC_BIN_PATH});
+	// re-package simulator related archs only. ( i386, x86_64 )
+	console.log('Compiling simulator...');
+	exec(`lipo -o WebRTC -create WebRTC-x86_64 WebRTC-i386`, { cwd: WEBRTC_BIN_PATH });
 } else if (process.argv[2] === '--device' || process.argv[2] === '-d') {
-  // re-package device related archs only. ( armv7, arm64 )
-  console.log('Compiling device...');
-  exec(`lipo -o WebRTC -create WebRTC-armv7 WebRTC-arm64`, {cwd: WEBRTC_BIN_PATH});
+	// re-package device related archs only. ( armv7, arm64 )
+	console.log('Compiling device...');
+	exec(`lipo -o WebRTC -create WebRTC-armv7 WebRTC-arm64`, { cwd: WEBRTC_BIN_PATH });
 } else if (process.argv[2] === '--list' || process.argv[2] === '-l') {
-  // List WebRTC architectures
-  console.log('List WebRTC architectures...');
-  console.log(exec(`file WebRTC`, {cwd: WEBRTC_BIN_PATH}).toString().trim());
+	// List WebRTC architectures
+	console.log('List WebRTC architectures...');
+	console.log(exec(`file WebRTC`, { cwd: WEBRTC_BIN_PATH }).toString().trim());
 } else if (process.argv[2] === '--clean' || process.argv[2] === '-l') {
-  // Delete WebRTC-* architectures
-  console.log('Clean WebRTC architectures...');
-  console.log(exec(`rm -f WebRTC-*`, {cwd: WEBRTC_BIN_PATH}).toString().trim());
+	// Delete WebRTC-* architectures
+	console.log('Clean WebRTC architectures...');
+	console.log(exec(`rm -f WebRTC-*`, { cwd: WEBRTC_BIN_PATH }).toString().trim());
 } else {
-  console.log('Unknow options');
+	console.log('Unknow options');
 }
 
 console.log('List WebRTC files...');
-console.log(exec('ls -ahl | grep WebRTC', {cwd: WEBRTC_BIN_PATH}).toString().trim());
+console.log(exec('ls -ahl | grep WebRTC', { cwd: WEBRTC_BIN_PATH }).toString().trim());
 console.log('Done! Remember to delete generated files ("WebRTC-*") if needed.');

--- a/extra/renderer-and-libwebrtc-tests.js
+++ b/extra/renderer-and-libwebrtc-tests.js
@@ -5,22 +5,21 @@ var cordova = window.cordova;
 
 // Expose WebRTC Globals
 if (cordova && cordova.plugins && cordova.plugins.iosrtc) {
-  cordova.plugins.iosrtc.registerGlobals();
-  //cordova.plugins.iosrtc.debug.disable('*', true);
-  //cordova.plugins.iosrtc.debug.enable('*', true);
-  cordova.plugins.iosrtc.initAudioDevices();
-  cordova.plugins.iosrtc.turnOnSpeaker(true);
-  cordova.plugins.iosrtc.requestPermission(true, true, function (result) {
-    console.log('requestPermission.result', result);
-  });
+	cordova.plugins.iosrtc.registerGlobals();
+	//cordova.plugins.iosrtc.debug.disable('*', true);
+	//cordova.plugins.iosrtc.debug.enable('*', true);
+	cordova.plugins.iosrtc.initAudioDevices();
+	cordova.plugins.iosrtc.turnOnSpeaker(true);
+	cordova.plugins.iosrtc.requestPermission(true, true, function (result) {
+		console.log('requestPermission.result', result);
+	});
 }
-
 
 //
 // Container
 //
 
-document.body.innerHTML = "";
+document.body.innerHTML = '';
 var appContainer = document.body;
 
 //
@@ -30,49 +29,57 @@ var appContainer = document.body;
 var localStream;
 var localVideoEl;
 function TestGetUserMedia() {
+	// Note: Support for Multiple TestRTCPeerConnection calls
+	if (localStream) {
+		// Close local Stream if already connected
+		localStream.stop();
 
-  // Note: Support for Multiple TestRTCPeerConnection calls
-  if (localStream) {
+		// Clear local video element
+		if (localVideoEl.srcObject) {
+			localVideoEl.srcObject = null;
+			if (localVideoEl.parentNode === appContainer) {
+				appContainer.removeChild(localVideoEl);
+			}
+		}
+	}
 
-    // Close local Stream if already connected
-    localStream.stop();
+	localVideoEl = document.createElement('video');
+	localVideoEl.setAttribute('autoplay', 'autoplay');
+	localVideoEl.setAttribute('playsinline', 'playsinline');
 
-    // Clear local video element
-    if (localVideoEl.srcObject) {
-      localVideoEl.srcObject = null;
-      if (localVideoEl.parentNode === appContainer) {
-        appContainer.removeChild(localVideoEl);
-      }
-    }
-  }
+	// Note: Test CSS positioning
+	localVideoEl.style.backgroundColor = 'purple'; // Cause zIndex - 1 failure
+	localVideoEl.style.position = 'absolute';
+	localVideoEl.style.top = 0;
+	localVideoEl.style.left = 0;
+	localVideoEl.style.width = '100px';
+	localVideoEl.style.height = '100px';
+	localVideoEl.style.transform = 'scaleX(-1)';
+	appContainer.appendChild(localVideoEl);
 
-  localVideoEl = document.createElement('video');
-  localVideoEl.setAttribute('autoplay', 'autoplay');
-  localVideoEl.setAttribute('playsinline', 'playsinline');
+	navigator.mediaDevices.enumerateDevices().then(
+		function (devices) {
+			console.log('getMediaDevices.ok', devices);
+			devices.forEach(function (device, idx) {
+				console.log(
+					'getMediaDevices.devices',
+					idx,
+					device.label,
+					device.kind,
+					device.deviceId
+				);
+			});
+		},
+		function (err) {
+			console.log('getMediaDevices.err', err);
+		}
+	);
 
-  // Note: Test CSS positioning
-  localVideoEl.style.backgroundColor = 'purple'; // Cause zIndex - 1 failure
-  localVideoEl.style.position = 'absolute';
-  localVideoEl.style.top = 0;
-  localVideoEl.style.left = 0;
-  localVideoEl.style.width = "100px";
-  localVideoEl.style.height = "100px";
-  localVideoEl.style.transform = "scaleX(-1)";
-  appContainer.appendChild(localVideoEl);
-
-  navigator.mediaDevices.enumerateDevices().then(function (devices) {
-      console.log('getMediaDevices.ok', devices);
-      devices.forEach(function (device, idx) {
-        console.log('getMediaDevices.devices', idx, device.label, device.kind, device.deviceId);
-      });
-  }, function (err) {
-      console.log('getMediaDevices.err', err);
-  });
-
-  return navigator.mediaDevices.getUserMedia({
-    video: true,
-    audio: true
-    /*
+	return navigator.mediaDevices
+		.getUserMedia({
+			video: true,
+			audio: true
+			/*
     video: {
       // Test Back Camera
       //deviceId: 'com.apple.avfoundation.avcapturedevice.built-in_video:0'
@@ -84,90 +91,92 @@ function TestGetUserMedia() {
     audio: {
       exact: 'Built-In Microphone'
     }*/
-  }).then(function (stream) {
+		})
+		.then(function (stream) {
+			console.log('getUserMedia.stream', stream);
+			console.log('getUserMedia.stream.getTracks', stream.getTracks());
 
-    console.log('getUserMedia.stream', stream);
-    console.log('getUserMedia.stream.getTracks', stream.getTracks());
+			// Note: Expose for debug
+			localStream = stream;
 
-    // Note: Expose for debug
-    localStream = stream;
+			// Attach local stream to video element
+			localVideoEl.srcObject = localStream;
 
-    // Attach local stream to video element
-    localVideoEl.srcObject = localStream;
+			// Test HTML over Video element
+			TestPluginMediaStreamRenderer(localVideoEl);
 
-    // Test HTML over Video element
-    TestPluginMediaStreamRenderer(localVideoEl);
-
-    return localStream;
-
-  }).catch(function (err) {
-    console.log('getUserMediaError', err, err.stack);
-  });
+			return localStream;
+		})
+		.catch(function (err) {
+			console.log('getUserMediaError', err, err.stack);
+		});
 }
-
 
 var useAnimateVideo = false;
 function TestPluginMediaStreamRenderer(localVideoEl) {
+	// Animate video position
+	var currentPosition = {
+		x: 0,
+		y: 0
+	};
 
-  // Animate video position
-  var currentPosition = {
-    x: 0,
-    y: 0
-  };
+	var animateTimer;
+	function animateVideo() {
+		currentPosition.x =
+			currentPosition.x < window.innerWidth - parseInt(localVideoEl.style.width, 10)
+				? currentPosition.x + 1
+				: 0;
+		currentPosition.y =
+			currentPosition.y < window.innerHeight - parseInt(localVideoEl.style.height, 10)
+				? currentPosition.y + 1
+				: 0;
 
-  var animateTimer;
-  function animateVideo() {
+		localVideoEl.style.top = currentPosition.y + 'px';
+		localVideoEl.style.left = currentPosition.x + 'px';
 
-    currentPosition.x = currentPosition.x < (window.innerWidth - parseInt(localVideoEl.style.width, 10)) ? currentPosition.x + 1 : 0;
-    currentPosition.y = currentPosition.y < (window.innerHeight - parseInt(localVideoEl.style.height, 10)) ? currentPosition.y + 1 : 0;
+		if (cordova && cordova.plugins && cordova.plugins.iosrtc) {
+			//cordova.plugins.iosrtc.refreshVideos();
+		}
 
-    localVideoEl.style.top = currentPosition.y + 'px';
-    localVideoEl.style.left = currentPosition.x + 'px';
+		return (animateTimer = requestAnimationFrame(animateVideo));
+	}
 
-    if (cordova && cordova.plugins && cordova.plugins.iosrtc) {
-      //cordova.plugins.iosrtc.refreshVideos();
-    }
+	if (useAnimateVideo) {
+		animateTimer = animateVideo();
+	}
 
-    return (animateTimer = requestAnimationFrame(animateVideo));
-  }
+	//
+	// Test Video behind Element
+	//
 
-  if (useAnimateVideo) {
-    animateTimer = animateVideo();
-  }
+	// Note: Test HTML over video requiring Z-Index -1 and transparent <html> and <body>
+	document.body.style.background = 'transparent';
+	document.documentElement.style.background = 'transparent';
+	localVideoEl.style.backgroundColor = '';
+	localVideoEl.style.zIndex = -1;
 
-  //
-  // Test Video behind Element
-  //
+	var overEl = document.createElement('button');
+	overEl.style.backgroundColor = 'red';
+	overEl.style.position = 'absolute';
+	overEl.style.left = 0;
+	overEl.style.top = 0;
+	overEl.style.width = '100px';
+	overEl.style.height = '100px';
 
-  // Note: Test HTML over video requiring Z-Index -1 and transparent <html> and <body>
-  document.body.style.background = "transparent";
-  document.documentElement.style.background = "transparent";
-  localVideoEl.style.backgroundColor = '';
-  localVideoEl.style.zIndex = -1;
+	overEl.addEventListener('click', function () {
+		overEl.style.backgroundColor = overEl.style.backgroundColor === 'red' ? 'green' : 'red';
 
-  var overEl = document.createElement('button');
-  overEl.style.backgroundColor = 'red';
-  overEl.style.position = 'absolute';
-  overEl.style.left = 0;
-  overEl.style.top = 0;
-  overEl.style.width = "100px";
-  overEl.style.height = "100px";
+		if (overEl.style.backgroundColor === 'red') {
+			animateTimer = animateVideo();
+		} else {
+			cancelAnimationFrame(animateTimer);
+		}
+	});
 
-  overEl.addEventListener('click', function () {
-    overEl.style.backgroundColor = overEl.style.backgroundColor === 'red' ? 'green' : 'red';
+	appContainer.appendChild(overEl);
 
-    if (overEl.style.backgroundColor === 'red') {
-      animateTimer = animateVideo();
-    } else {
-      cancelAnimationFrame(animateTimer);
-    }
-  });
-
-  appContainer.appendChild(overEl);
-
-  overEl.style.left = ((window.innerWidth / 2)  - parseInt(overEl.style.width, 10)) + 'px';
-  overEl.style.top  = ((window.innerHeight / 2) - parseInt(overEl.style.height, 10)) + 'px';
-
+	overEl.style.left = window.innerWidth / 2 - parseInt(overEl.style.width, 10) + 'px';
+	overEl.style.top = window.innerHeight / 2 - parseInt(overEl.style.height, 10) + 'px';
 }
 
 //
@@ -175,313 +184,311 @@ function TestPluginMediaStreamRenderer(localVideoEl) {
 //
 
 var peerConnectionConfig = {
-    offerToReceiveVideo: true,
-    //iceTransportPolicy: 'relay',
-    sdpSemantics: 'unified-plan',
-    offerToReceiveAudio: true,
-    //sdpSemantics: 'plan-b',
-    //bundlePolicy: 'max-compat',
-    //rtcpMuxPolicy: 'negotiate',
-    iceServers: [
-        {
-            url: "stun:stun.stunprotocol.org"
-        }
-    ]
+	offerToReceiveVideo: true,
+	//iceTransportPolicy: 'relay',
+	sdpSemantics: 'unified-plan',
+	offerToReceiveAudio: true,
+	//sdpSemantics: 'plan-b',
+	//bundlePolicy: 'max-compat',
+	//rtcpMuxPolicy: 'negotiate',
+	iceServers: [
+		{
+			url: 'stun:stun.stunprotocol.org'
+		}
+	]
 };
 
 // This plugin handle 'addstream' and 'track' event for MediaStream creation.
 var useTrackEvent = Object.getOwnPropertyDescriptors(RTCPeerConnection.prototype).ontrack;
 
 var pc1 = new RTCPeerConnection(peerConnectionConfig),
-    pc2 = new RTCPeerConnection(peerConnectionConfig);
+	pc2 = new RTCPeerConnection(peerConnectionConfig);
 
 var sendChannel, receiveChannel;
 function TestPeerDataChannel() {
-  sendChannel = pc1.createDataChannel("sendChannel");
+	sendChannel = pc1.createDataChannel('sendChannel');
 
-  sendChannel.addEventListener('message',  function (event) {
-    console.log('sendChannel.message', event, event.data);
-  });
+	sendChannel.addEventListener('message', function (event) {
+		console.log('sendChannel.message', event, event.data);
+	});
 
-  sendChannel.addEventListener('open', function (event) {
-      console.log('sendChannel.open', event);
-      sendChannel.send("data message Date: " + new Date());
-  });
+	sendChannel.addEventListener('open', function (event) {
+		console.log('sendChannel.open', event);
+		sendChannel.send('data message Date: ' + new Date());
+	});
 
-  sendChannel.addEventListener('close', function (event) {
-      console.log('sendChannel.close', event);
-  });
+	sendChannel.addEventListener('close', function (event) {
+		console.log('sendChannel.close', event);
+	});
 
-  pc2.addEventListener('datachannel', function (event) {
-    receiveChannel = event.channel;
-    receiveChannel.addEventListener('message',  function (event) {
-      console.log('receiveChannel.message', event, event.data);
-    });
-    receiveChannel.addEventListener('open',  function (event) {
-      console.log('receiveChannel.open', event);
-    });
-    receiveChannel.addEventListener('close',  function (event) {
-      console.log('receiveChannel.close', event);
-    });
-  });
+	pc2.addEventListener('datachannel', function (event) {
+		receiveChannel = event.channel;
+		receiveChannel.addEventListener('message', function (event) {
+			console.log('receiveChannel.message', event, event.data);
+		});
+		receiveChannel.addEventListener('open', function (event) {
+			console.log('receiveChannel.open', event);
+		});
+		receiveChannel.addEventListener('close', function (event) {
+			console.log('receiveChannel.close', event);
+		});
+	});
 }
 
 var peerVideoEl;
 var peerStream;
 function TestRTCPeerConnection(localStream) {
+	// Note: Support for Multiple TestRTCPeerConnection calls
+	if (peerStream) {
+		// Close peer Stream if already connected
+		peerStream.stop();
 
-  // Note: Support for Multiple TestRTCPeerConnection calls
-  if (peerStream) {
+		// Clear peer video element
+		if (peerVideoEl.srcObject) {
+			peerVideoEl.srcObject = null;
+			appContainer.removeChild(peerVideoEl);
+		}
 
-    // Close peer Stream if already connected
-    peerStream.stop();
+		// Disconnect peer
+		if (pc1.iceConnectionState === 'completed') {
+			pc1.close();
 
-    // Clear peer video element
-    if (peerVideoEl.srcObject) {
-      peerVideoEl.srcObject = null;
-      appContainer.removeChild(peerVideoEl);
-    }
+			// Current you cannot reuse previous RTCPeerConnection
+			pc1 = new RTCPeerConnection();
+			pc2 = new RTCPeerConnection();
+		}
+	}
 
-    // Disconnect peer
-    if (pc1.iceConnectionState === 'completed') {
-      pc1.close();
+	if (useTrackEvent) {
+		// Add local stream tracks to RTCPeerConnection
+		var localPeerStream = new MediaStream();
+		localStream.getTracks().forEach(function (track) {
+			console.log('pc1.addTrack', track, localPeerStream);
+			pc1.addTrack(track, localPeerStream);
+		});
+	} else {
+		// Note: Deprecated but supported
+		pc1.addStream(localStream);
 
-      // Current you cannot reuse previous RTCPeerConnection
-      pc1 = new RTCPeerConnection();
-      pc2 = new RTCPeerConnection();
-    }
-  }
+		// Note: Deprecated Test removeStream
+		// pc1.removeStream(pc1.getLocalStreams()[0]);<
+	}
 
-  if (useTrackEvent) {
-     
-    // Add local stream tracks to RTCPeerConnection
-    var localPeerStream = new MediaStream();
-    localStream.getTracks().forEach(function (track) {
-      console.log('pc1.addTrack', track, localPeerStream);
-      pc1.addTrack(track, localPeerStream);
-    });
-        
-  // Note: Deprecated but supported 
-  } else {
-     pc1.addStream(localStream);
+	function onAddIceCandidate(pc, can) {
+		console.log('addIceCandidate', pc, can);
+		return (
+			can &&
+			pc.addIceCandidate(can).catch(function (err) {
+				console.log('addIceCandidateError', err);
+			})
+		);
+	}
 
-     // Note: Deprecated Test removeStream
-     // pc1.removeStream(pc1.getLocalStreams()[0]);<
-  }
+	pc1.addEventListener('icecandidate', function (e) {
+		onAddIceCandidate(pc2, e.candidate);
+	});
 
-  function onAddIceCandidate(pc, can) {
-    console.log('addIceCandidate', pc, can);
-    return can && pc.addIceCandidate(can).catch(function (err) {
-      console.log('addIceCandidateError', err);
-    });
-  }
+	pc2.addEventListener('icecandidate', function (e) {
+		onAddIceCandidate(pc1, e.candidate);
+	});
 
-  pc1.addEventListener('icecandidate', function (e) {
-    onAddIceCandidate(pc2, e.candidate);
-  });
+	pc2.addEventListener('track', function (e) {
+		console.log('pc2.track', e);
+	});
 
-  pc2.addEventListener('icecandidate', function (e) {
-    onAddIceCandidate(pc1, e.candidate);
-  });
+	pc2.addEventListener('removestream', function (e) {
+		console.log('pc2.removeStream', e);
+	});
 
-  pc2.addEventListener('track', function (e) {
-    console.log('pc2.track', e);
-  });
+	function setPeerVideoStream(stream) {
+		peerVideoEl = document.createElement('video');
+		peerVideoEl.setAttribute('autoplay', 'autoplay');
+		peerVideoEl.setAttribute('playsinline', 'playsinline');
 
-  pc2.addEventListener('removestream', function (e) {
-    console.log('pc2.removeStream', e);
-  });
+		// Note: Test Object-fix
+		peerVideoEl.style.objectFit = 'cover';
 
-  function setPeerVideoStream(stream) {
+		// Note: Test CSS positioning
+		peerVideoEl.style.backgroundColor = 'blue';
+		peerVideoEl.style.position = 'fixed';
+		peerVideoEl.style.width = '100px';
+		peerVideoEl.style.height = '100px';
+		peerVideoEl.style.top = 0;
+		peerVideoEl.style.left = window.innerWidth - parseInt(peerVideoEl.style.width, 10) + 'px';
+		appContainer.appendChild(peerVideoEl);
 
-    peerVideoEl = document.createElement('video');
-    peerVideoEl.setAttribute('autoplay', 'autoplay');
-    peerVideoEl.setAttribute('playsinline', 'playsinline');
+		// Note: Expose for debug
+		peerStream = stream;
 
-    // Note: Test Object-fix
-    peerVideoEl.style.objectFit = "cover";
+		// Attach peer stream to video element
+		peerVideoEl.srcObject = peerStream;
+	}
 
-    // Note: Test CSS positioning
-    peerVideoEl.style.backgroundColor = 'blue';
-    peerVideoEl.style.position = 'fixed';
-    peerVideoEl.style.width = "100px";
-    peerVideoEl.style.height = "100px";
-    peerVideoEl.style.top = 0;
-    peerVideoEl.style.left = (window.innerWidth - parseInt(peerVideoEl.style.width, 10)) + 'px';
-    appContainer.appendChild(peerVideoEl);
+	if (useTrackEvent) {
+		var newPeerStream;
+		pc2.addEventListener('track', function (e) {
+			console.log('pc2.track', e);
+			newPeerStream = e.streams[0] || newPeerStream || new MediaStream();
+			setPeerVideoStream(newPeerStream);
+			newPeerStream.addTrack(e.track);
+		});
+	} else {
+		// Note: Deprecated but supported
+		pc2.addEventListener('addstream', function (e) {
+			console.log('pc2.addStream', e);
+			setPeerVideoStream(e.stream);
+		});
+	}
 
-    // Note: Expose for debug
-    peerStream = stream;
+	pc1.addEventListener('iceconnectionstatechange', function (e) {
+		console.log('pc1.iceConnectionState', e, pc1.iceConnectionState);
 
-    // Attach peer stream to video element
-    peerVideoEl.srcObject = peerStream;
-  }
+		if (pc1.iceConnectionState === 'completed') {
+			console.log('pc1.getSenders', pc1.getSenders());
+			console.log('pc2.getReceivers', pc2.getReceivers());
+		}
+	});
 
-  if (useTrackEvent) {
-    var newPeerStream;
-    pc2.addEventListener('track', function(e) {
-      console.log('pc2.track', e);
-      newPeerStream = e.streams[0] || newPeerStream || new MediaStream();
-      setPeerVideoStream(newPeerStream);
-      newPeerStream.addTrack(e.track);   
-    });
+	pc1.addEventListener('icegatheringstatechange', function (e) {
+		console.log('pc1.iceGatheringStateChange', e);
+	});
 
-  // Note: Deprecated but supported
-  } else {
-    pc2.addEventListener('addstream', function(e) {
-	  console.log('pc2.addStream', e);
-      setPeerVideoStream(e.stream);
-    });
-  }
+	// https://stackoverflow.com/questions/48963787/failed-to-set-local-answer-sdp-called-in-wrong-state-kstable
+	// https://bugs.chromium.org/p/chromium/issues/detail?id=740501
+	var isNegotiating = false;
+	pc1.addEventListener('signalingstatechange', function (e) {
+		console.log('pc1.signalingstatechange', e);
+		isNegotiating = pc1.signalingState !== 'stable';
+	});
 
-  pc1.addEventListener('iceconnectionstatechange', function (e) {
-    console.log('pc1.iceConnectionState', e, pc1.iceConnectionState);
+	pc1.addEventListener('negotiationneeded', function (e) {
+		if (isNegotiating) {
+			// Should not trigger on iosrtc cause of PluginRTCPeerConnection.swift fix
+			console.log('pc1.negotiatioNeeded', 'SKIP nested negotiations');
+			return;
+		}
+		isNegotiating = true;
 
-    if (pc1.iceConnectionState === 'completed') {
-      console.log('pc1.getSenders', pc1.getSenders());
-      console.log('pc2.getReceivers', pc2.getReceivers());
-    }
-  });
+		console.log('pc1.negotiatioNeeded', e);
 
-  pc1.addEventListener('icegatheringstatechange', function (e) {
-    console.log('pc1.iceGatheringStateChange', e);
-  });
-
-  // https://stackoverflow.com/questions/48963787/failed-to-set-local-answer-sdp-called-in-wrong-state-kstable
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=740501
-  var isNegotiating = false;
-  pc1.addEventListener('signalingstatechange', function (e) {
-    console.log('pc1.signalingstatechange',  e);
-    isNegotiating = (pc1.signalingState !== "stable");
-  });
-
-  pc1.addEventListener('negotiationneeded', function (e) {
-
-    if (isNegotiating) {
-      // Should not trigger on iosrtc cause of PluginRTCPeerConnection.swift fix
-      console.log("pc1.negotiatioNeeded", "SKIP nested negotiations");
-      return;
-    }
-    isNegotiating = true;
-
-    console.log('pc1.negotiatioNeeded', e);
-
-    return pc1.createOffer().then(function (d) {
-      var desc = {
-        type: d.type,
-        sdp: d.sdp
-      };
-      console.log('pc1.setLocalDescription', desc);
-      return pc1.setLocalDescription(desc);
-    }).then(function () {
-      var desc = {
-        type: pc1.localDescription.type,
-        sdp: pc1.localDescription.sdp
-      };
-      console.log('pc2.setLocalDescription', desc);
-      return pc2.setRemoteDescription(desc);
-    }).then(function () {
-      console.log('pc2.createAnswer');
-      return pc2.createAnswer();
-    }).then(function (d) {
-      var desc = {
-        type: d.type,
-        sdp: d.sdp
-      };
-      console.log('pc2.setLocalDescription', desc);
-      return pc2.setLocalDescription(d);
-    }).then(function () {
-      var desc = {
-        type: pc2.localDescription.type,
-        sdp: pc2.localDescription.sdp
-      };
-      console.log('pc1.setRemoteDescription', desc);
-      return pc1.setRemoteDescription(desc);
-    }).then(function () {
-      TestMediaRenderCatpure(peerVideoEl);
-      TestMediaRenderCatpure(localVideoEl);
-      TestPeerDataChannel();
-    }).catch(function (err) {
-      console.log('pc1.createOfferError', err);
-    });
-  });
+		return pc1
+			.createOffer()
+			.then(function (d) {
+				var desc = {
+					type: d.type,
+					sdp: d.sdp
+				};
+				console.log('pc1.setLocalDescription', desc);
+				return pc1.setLocalDescription(desc);
+			})
+			.then(function () {
+				var desc = {
+					type: pc1.localDescription.type,
+					sdp: pc1.localDescription.sdp
+				};
+				console.log('pc2.setLocalDescription', desc);
+				return pc2.setRemoteDescription(desc);
+			})
+			.then(function () {
+				console.log('pc2.createAnswer');
+				return pc2.createAnswer();
+			})
+			.then(function (d) {
+				var desc = {
+					type: d.type,
+					sdp: d.sdp
+				};
+				console.log('pc2.setLocalDescription', desc);
+				return pc2.setLocalDescription(d);
+			})
+			.then(function () {
+				var desc = {
+					type: pc2.localDescription.type,
+					sdp: pc2.localDescription.sdp
+				};
+				console.log('pc1.setRemoteDescription', desc);
+				return pc1.setRemoteDescription(desc);
+			})
+			.then(function () {
+				TestMediaRenderCatpure(peerVideoEl);
+				TestMediaRenderCatpure(localVideoEl);
+				TestPeerDataChannel();
+			})
+			.catch(function (err) {
+				console.log('pc1.createOfferError', err);
+			});
+	});
 }
 
 var canvasEl;
 function TestMediaRenderCatpure(videoEl) {
+	if (!canvasEl) {
+		canvasEl = document.createElement('canvas');
+	}
 
-  if (!canvasEl) {
-    canvasEl = document.createElement('canvas');
-  }
-
-  var ctx = canvasEl.getContext("2d");
-  canvasEl.style.position = 'absolute';
-  canvasEl.style.left = 0;
-  canvasEl.style.bottom = 0;
-  appContainer.appendChild(canvasEl);
-  var image = new Image();
-  image.addEventListener('load', function() {
-    canvasEl.width = image.width;
-    canvasEl.height = image.height;
-    ctx.drawImage(image, 0, 0);
-  });
-  localVideoEl.render.save(function (data) {
-    image.src = "data:image/jpg;base64," + data;
-  });
+	var ctx = canvasEl.getContext('2d');
+	canvasEl.style.position = 'absolute';
+	canvasEl.style.left = 0;
+	canvasEl.style.bottom = 0;
+	appContainer.appendChild(canvasEl);
+	var image = new Image();
+	image.addEventListener('load', function () {
+		canvasEl.width = image.width;
+		canvasEl.height = image.height;
+		ctx.drawImage(image, 0, 0);
+	});
+	localVideoEl.render.save(function (data) {
+		image.src = 'data:image/jpg;base64,' + data;
+	});
 }
 
 var testMediaRenderCatpureAnimateFrame;
 function TestMediaRenderCatpureAnimate() {
-  TestMediaRenderCatpure(peerVideoEl);
-  testMediaRenderCatpureAnimateFrame = requestAnimationFrame(TestMediaRenderCatpureAnimate);
+	TestMediaRenderCatpure(peerVideoEl);
+	testMediaRenderCatpureAnimateFrame = requestAnimationFrame(TestMediaRenderCatpureAnimate);
 }
-
 
 // Disabled to avoid confusion with remoteStream
 var cloneStream;
 var cloneVideoEl;
 function TestPluginMediaStreamClone(mediaStream) {
-  cloneVideoEl = document.createElement('video');
-  cloneVideoEl.setAttribute('autoplay', 'autoplay');
-  cloneVideoEl.setAttribute('playsinline', 'playsinline');
-  cloneVideoEl.style.backgroundColor = 'purple';
-  cloneVideoEl.style.position = 'absolute';
-  cloneVideoEl.style.bottom = 0;
-  cloneVideoEl.style.left = 0;
-  cloneVideoEl.style.width = "100px";
-  cloneVideoEl.style.height = "100px";
-  cloneVideoEl.style.transform = "scaleX(-1)";
+	cloneVideoEl = document.createElement('video');
+	cloneVideoEl.setAttribute('autoplay', 'autoplay');
+	cloneVideoEl.setAttribute('playsinline', 'playsinline');
+	cloneVideoEl.style.backgroundColor = 'purple';
+	cloneVideoEl.style.position = 'absolute';
+	cloneVideoEl.style.bottom = 0;
+	cloneVideoEl.style.left = 0;
+	cloneVideoEl.style.width = '100px';
+	cloneVideoEl.style.height = '100px';
+	cloneVideoEl.style.transform = 'scaleX(-1)';
 
-  cloneStream = mediaStream.clone();
-  cloneVideoEl.srcObject = cloneStream;
+	cloneStream = mediaStream.clone();
+	cloneVideoEl.srcObject = cloneStream;
 
-  appContainer.appendChild(cloneVideoEl);
+	appContainer.appendChild(cloneVideoEl);
 }
 
 var useWebRTCAdapter = false;
 
 // Expose webrtc-adapter
 if (useWebRTCAdapter && typeof window.adapter === 'undefined') {
-
-    // load adapter.js
-    var version = 'latest';
-    var script = document.createElement("script");
-    script.type = "text/javascript";
-    //script.src = "adapter-latest.js";
-    script.src = "https://webrtc.github.io/adapter/adapter-" + version + ".js";
-    script.async = false;
-    document.getElementsByTagName("head")[0].appendChild(script);
-    script.addEventListener('load', function () {
-      console.log('useWebRTCAdapter.loaded', script.src);
-      TestGetUserMedia().then(function (localStream) {
-        TestRTCPeerConnection(localStream);
-      });
-    });
+	// load adapter.js
+	var version = 'latest';
+	var script = document.createElement('script');
+	script.type = 'text/javascript';
+	//script.src = "adapter-latest.js";
+	script.src = 'https://webrtc.github.io/adapter/adapter-' + version + '.js';
+	script.async = false;
+	document.getElementsByTagName('head')[0].appendChild(script);
+	script.addEventListener('load', function () {
+		console.log('useWebRTCAdapter.loaded', script.src);
+		TestGetUserMedia().then(function (localStream) {
+			TestRTCPeerConnection(localStream);
+		});
+	});
 } else {
-  TestGetUserMedia().then(function (localStream) {
-    TestRTCPeerConnection(localStream);
-  });
+	TestGetUserMedia().then(function (localStream) {
+		TestRTCPeerConnection(localStream);
+	});
 }
-
-
-

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,37 +10,34 @@ var gulp = require('gulp'),
 	path = require('path'),
 	fs = require('fs'),
 	derequire = require('gulp-derequire'),
-
-/**
- * Constants.
- */
+	/**
+	 * Constants.
+	 */
 	PKG = require('./package.json'),
-
-/**
- * Banner.
- */
+	/**
+	 * Banner.
+	 */
 	banner = fs.readFileSync('banner.txt').toString(),
 	banner_options = {
 		pkg: PKG,
-		currentYear: (new Date()).getFullYear()
+		currentYear: new Date().getFullYear()
 	};
-
 
 gulp.task('lint', function () {
 	var src = ['gulpfile.js', 'js/**/*.js', 'hooks/**/*.js', 'extra/**/*.js'];
 
-	return gulp.src(src)
-		.pipe(jshint('.jshintrc'))  // Enforce good practics.
-		.pipe(jshint.reporter('jshint-stylish', {verbose: true}))
+	return gulp
+		.src(src)
+		.pipe(jshint('.jshintrc')) // Enforce good practics.
+		.pipe(jshint.reporter('jshint-stylish', { verbose: true }))
 		.pipe(jshint.reporter('fail'));
 });
-
 
 gulp.task('browserify', function () {
 	return browserify([path.join(__dirname, PKG.main)], {
 		standalone: 'iosrtc'
 	})
-		.exclude('cordova/exec')  // Exclude require('cordova/exec').
+		.exclude('cordova/exec') // Exclude require('cordova/exec').
 		.bundle()
 		.pipe(vinyl_source_stream(PKG.name + '.js'))
 		.pipe(vinyl_buffer())
@@ -48,6 +45,5 @@ gulp.task('browserify', function () {
 		.pipe(derequire())
 		.pipe(gulp.dest('www/'));
 });
-
 
 gulp.task('default', gulp.series('lint', 'browserify'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@
  * Dependencies.
  */
 var gulp = require('gulp'),
-	eslint = require('gulp-eslint'),
 	browserify = require('browserify'),
 	vinyl_source_stream = require('vinyl-source-stream'),
 	vinyl_buffer = require('vinyl-buffer'),
@@ -32,7 +31,6 @@ gulp.task('lint', function () {
 
 	return gulp.src(src)
 		.pipe(jshint('.jshintrc'))  // Enforce good practics.
-		.pipe(eslint('.eslintrc'))  // Enforce style guide.
 		.pipe(jshint.reporter('jshint-stylish', {verbose: true}))
 		.pipe(jshint.reporter('fail'));
 });

--- a/js/Errors.js
+++ b/js/Errors.js
@@ -1,17 +1,13 @@
 /**
  * Expose an object with WebRTC Errors.
  */
-var Errors = module.exports = {},
-
-
-/**
- * Local variables.
- */
+var Errors = (module.exports = {}),
+	/**
+	 * Local variables.
+	 */
 	IntermediateInheritor = function () {};
 
-
 IntermediateInheritor.prototype = Error.prototype;
-
 
 /**
  * Create error classes.
@@ -20,7 +16,6 @@ addError('InvalidStateError');
 addError('InvalidSessionDescriptionError');
 addError('InternalError');
 addError('MediaStreamError');
-
 
 function addError(name) {
 	Errors[name] = function () {
@@ -44,10 +39,9 @@ function addError(name) {
 // Detect callback usage to assist 5.0.1 to 5.0.2 migration
 // TODO remove on 6.0.0
 Errors.detectDeprecatedCallbaksUsage = function detectDeprecatedCallbaksUsage(funcName, arg) {
-	if (
-		typeof arg[1] === 'function' ||
-			typeof arg[2] === 'function'
-	) {
-		throw new Error('Callbacks are not supported by "' + funcName + '" anymore, use Promise instead.');
+	if (typeof arg[1] === 'function' || typeof arg[2] === 'function') {
+		throw new Error(
+			'Callbacks are not supported by "' + funcName + '" anymore, use Promise instead.'
+		);
 	}
 };

--- a/js/EventTarget.js
+++ b/js/EventTarget.js
@@ -1,8 +1,7 @@
 /**
  * Dependencies.
  */
-var
-	YaetiEventTarget = require('yaeti').EventTarget;
+var YaetiEventTarget = require('yaeti').EventTarget;
 
 var EventTarget = function () {
 	YaetiEventTarget.call(this);
@@ -11,13 +10,15 @@ var EventTarget = function () {
 EventTarget.prototype = Object.create(YaetiEventTarget.prototype);
 EventTarget.prototype.constructor = EventTarget;
 
-Object.defineProperties(EventTarget.prototype, Object.getOwnPropertyDescriptors(YaetiEventTarget.prototype));
+Object.defineProperties(
+	EventTarget.prototype,
+	Object.getOwnPropertyDescriptors(YaetiEventTarget.prototype)
+);
 
 EventTarget.prototype.dispatchEvent = function (event) {
-
 	Object.defineProperty(event, 'target', {
-	  value: this,
-	  writable: false
+		value: this,
+		writable: false
 	});
 
 	YaetiEventTarget.prototype.dispatchEvent.call(this, event);

--- a/js/MediaDevices.js
+++ b/js/MediaDevices.js
@@ -10,13 +10,11 @@ module.exports = MediaDevices;
 /**
  * Dependencies.
  */
-var
-	EventTarget = require('./EventTarget'),
+var EventTarget = require('./EventTarget'),
 	getUserMedia = require('./getUserMedia'),
 	enumerateDevices = require('./enumerateDevices');
 
 function MediaDevices(data) {
-
 	//ondevicechange
 	//enumerateDevices
 	//getDisplayMedia
@@ -45,37 +43,36 @@ MediaDevices.prototype.enumerateDevices = function () {
 MediaDevices.prototype.getSupportedConstraints = function () {
 	return {
 		// Supported
-		"height": true,
-		"width": true,
-		"deviceId": true,
-		"frameRate": true,
-		"sampleRate": true,
-		"aspectRatio": true,
+		height: true,
+		width: true,
+		deviceId: true,
+		frameRate: true,
+		sampleRate: true,
+		aspectRatio: true,
 		// Not Supported
-		"autoGainControl": false,
-		"brightness": false,
-		"channelCount": false,
-		"colorTemperature": false,
-		"contrast": false,
-		"echoCancellation": false,
-		"exposureCompensation": false,
-		"exposureMode": false,
-		"exposureTime": false,
-		"facingMode": true,
-		"focusDistance": false,
-		"focusMode": false,
-		"groupId": false,
-		"iso": false,
-		"latency": false,
-		"noiseSuppression": false,
-		"pointsOfInterest": false,
-		"resizeMode": false,
-		"sampleSize": false,
-		"saturation": false,
-		"sharpness": false,
-		"torch": false,
-		"whiteBalanceMode": false,
-		"zoom": false
+		autoGainControl: false,
+		brightness: false,
+		channelCount: false,
+		colorTemperature: false,
+		contrast: false,
+		echoCancellation: false,
+		exposureCompensation: false,
+		exposureMode: false,
+		exposureTime: false,
+		facingMode: true,
+		focusDistance: false,
+		focusMode: false,
+		groupId: false,
+		iso: false,
+		latency: false,
+		noiseSuppression: false,
+		pointsOfInterest: false,
+		resizeMode: false,
+		sampleSize: false,
+		saturation: false,
+		sharpness: false,
+		torch: false,
+		whiteBalanceMode: false,
+		zoom: false
 	};
 };
-

--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -10,15 +10,13 @@ module.exports = MediaStream;
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:MediaStream'),
+var debug = require('debug')('iosrtc:MediaStream'),
 	exec = require('cordova/exec'),
 	EventTarget = require('./EventTarget'),
 	MediaStreamTrack = require('./MediaStreamTrack'),
-
-/**
- * Local variables.
- */
+	/**
+	 * Local variables.
+	 */
 
 	// Dictionary of MediaStreams (provided via getMediaStreams() class method).
 	// - key: MediaStream blobId.
@@ -28,7 +26,7 @@ var
 // TODO longer UUID like native call
 // - "4021904575-2849079001-3048689102-1644344044-4021904575-2849079001-3048689102-1644344044"
 function newMediaStreamId() {
-   return window.crypto.getRandomValues(new Uint32Array(4)).join('-');
+	return window.crypto.getRandomValues(new Uint32Array(4)).join('-');
 }
 
 // Save original MediaStream
@@ -46,9 +44,10 @@ function MediaStream(arg, id) {
 	// new MediaStream(originalMediaStream) // stream
 	// new MediaStream(originalMediaStreamTrack[]) // tracks
 	if (
-		!(arg instanceof window.Blob) &&
-			(arg instanceof originalMediaStream && typeof arg.getBlobId === 'undefined') ||
-				(Array.isArray(arg) && arg[0] instanceof originalMediaStreamTrack)
+		(!(arg instanceof window.Blob) &&
+			arg instanceof originalMediaStream &&
+			typeof arg.getBlobId === 'undefined') ||
+		(Array.isArray(arg) && arg[0] instanceof originalMediaStreamTrack)
 	) {
 		return new originalMediaStream(arg);
 	}
@@ -63,10 +62,9 @@ function MediaStream(arg, id) {
 	// Extend returned MediaTream with custom MediaStream
 	var stream;
 	if (originalMediaStream !== window.Blob) {
-		stream = new (Function.prototype.bind.apply(originalMediaStream.bind(this), [])); // jshint ignore:line
-
-	// Fallback on Blob if originalMediaStream is not a MediaStream and Emulate EventTarget
+		stream = new (Function.prototype.bind.apply(originalMediaStream.bind(this), []))();
 	} else {
+		// Fallback on Blob if originalMediaStream is not a MediaStream and Emulate EventTarget
 		stream = new Blob([blobId], {
 			type: 'stream'
 		});
@@ -101,10 +99,7 @@ function MediaStream(arg, id) {
 	mediaStreams[stream._blobId] = stream;
 
 	// Convert arg to array of tracks if possible
-	if (
-		(arg instanceof MediaStream) ||
-			(arg instanceof MediaStream.originalMediaStream)
-	) {
+	if (arg instanceof MediaStream || arg instanceof MediaStream.originalMediaStream) {
 		arg = arg.getTracks();
 	}
 
@@ -113,7 +108,9 @@ function MediaStream(arg, id) {
 			stream.addTrack(track);
 		});
 	} else if (typeof arg !== 'undefined') {
-		throw new TypeError("Failed to construct 'MediaStream': No matching constructor signature.");
+		throw new TypeError(
+			"Failed to construct 'MediaStream': No matching constructor signature."
+		);
 	}
 
 	function onResultOK(data) {
@@ -143,7 +140,10 @@ MediaStream.prototype = Object.create(originalMediaStream.prototype, {
 	}
 });
 
-Object.defineProperties(MediaStream.prototype, Object.getOwnPropertyDescriptors(EventTarget.prototype));
+Object.defineProperties(
+	MediaStream.prototype,
+	Object.getOwnPropertyDescriptors(EventTarget.prototype)
+);
 
 MediaStream.prototype.constructor = MediaStream;
 
@@ -165,7 +165,8 @@ MediaStream.getMediaStreams = function () {
 MediaStream.create = function (dataFromEvent) {
 	debug('create() | [dataFromEvent:%o]', dataFromEvent);
 
-	var trackId, track,
+	var trackId,
+		track,
 		stream = new MediaStream([], dataFromEvent.id);
 
 	// We do not use addTrack to prevent false positive "ERROR: video track not added" and "ERROR: audio track not added"
@@ -213,7 +214,6 @@ MediaStream.prototype.getAudioTracks = function () {
 	return tracks;
 };
 
-
 MediaStream.prototype.getVideoTracks = function () {
 	debug('getVideoTracks()');
 
@@ -228,7 +228,6 @@ MediaStream.prototype.getVideoTracks = function () {
 
 	return tracks;
 };
-
 
 MediaStream.prototype.getTracks = function () {
 	debug('getTracks()');
@@ -250,7 +249,6 @@ MediaStream.prototype.getTracks = function () {
 
 	return tracks;
 };
-
 
 MediaStream.prototype.getTrackById = function (id) {
 	debug('getTrackById()');
@@ -312,9 +310,7 @@ MediaStream.prototype.removeTrack = function (track) {
 	checkActive.call(this);
 };
 
-
 MediaStream.prototype.clone = function () {
-
 	var newStream = MediaStream();
 	this.getTracks().forEach(function (track) {
 		newStream.addTrack(track.clone());
@@ -342,14 +338,11 @@ MediaStream.prototype.stop = function () {
 	}
 };
 
-
 // TODO: API methods and events.
-
 
 /**
  * Private API.
  */
-
 
 MediaStream.prototype.emitConnected = function () {
 	debug('emitConnected()');
@@ -361,13 +354,16 @@ MediaStream.prototype.emitConnected = function () {
 	}
 	this.connected = true;
 
-	setTimeout(function (self) {
-		var event = new Event('connected');
-		Object.defineProperty(event, 'target', {value: self, enumerable: true});
-		self.dispatchEvent(event);
-	}, 0, self);
+	setTimeout(
+		function (self) {
+			var event = new Event('connected');
+			Object.defineProperty(event, 'target', { value: self, enumerable: true });
+			self.dispatchEvent(event);
+		},
+		0,
+		self
+	);
 };
-
 
 function addListenerForTrackEnded(track) {
 	var self = this;
@@ -383,7 +379,6 @@ function addListenerForTrackEnded(track) {
 	});
 }
 
-
 function checkActive() {
 	// A MediaStream object is said to be active when it has at least one MediaStreamTrack
 	// that has not ended. A MediaStream that does not have any tracks or only has tracks
@@ -396,7 +391,10 @@ function checkActive() {
 		return;
 	}
 
-	if (Object.keys(this._audioTracks).length === 0 && Object.keys(this._videoTracks).length === 0) {
+	if (
+		Object.keys(this._audioTracks).length === 0 &&
+		Object.keys(this._videoTracks).length === 0
+	) {
 		debug('no tracks, releasing MediaStream');
 
 		release();
@@ -432,7 +430,6 @@ function checkActive() {
 		exec(null, null, 'iosrtcPlugin', 'MediaStream_release', [self.id]);
 	}
 }
-
 
 function onEvent(data) {
 	var type = data.type,
@@ -471,7 +468,9 @@ function onEvent(data) {
 			}
 
 			if (!track) {
-				throw new Error('"removetrack" event fired on MediaStream for a non existing MediaStreamTrack');
+				throw new Error(
+					'"removetrack" event fired on MediaStream for a non existing MediaStreamTrack'
+				);
 			}
 
 			event = new Event('removetrack');

--- a/js/MediaStreamRenderer.js
+++ b/js/MediaStreamRenderer.js
@@ -3,17 +3,14 @@
  */
 module.exports = MediaStreamRenderer;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:MediaStreamRenderer'),
+var debug = require('debug')('iosrtc:MediaStreamRenderer'),
 	exec = require('cordova/exec'),
-	randomNumber = require('random-number').generator({min: 10000, max: 99999, integer: true}),
+	randomNumber = require('random-number').generator({ min: 10000, max: 99999, integer: true }),
 	EventTarget = require('./EventTarget'),
 	MediaStream = require('./MediaStream');
-
 
 function MediaStreamRenderer(element) {
 	debug('new() | [element:"%s"]', element);
@@ -93,8 +90,8 @@ MediaStreamRenderer.prototype.render = function (stream) {
 
 	if (stream.connected) {
 		connected();
-	// Otherwise subscribe to 'connected' event to emulate video elements events.
 	} else {
+		// Otherwise subscribe to 'connected' event to emulate video elements events.
 		stream.addEventListener('connected', function () {
 			if (self.stream !== stream) {
 				return;
@@ -162,7 +159,12 @@ MediaStreamRenderer.prototype.refresh = function () {
 	computedStyle = window.getComputedStyle(this.element);
 
 	// get background color
-	backgroundColorRgba = computedStyle.backgroundColor.replace(/rgba?\((.*)\)/, '$1').split(',').map(function(x){ return x.trim(); });
+	backgroundColorRgba = computedStyle.backgroundColor
+		.replace(/rgba?\((.*)\)/, '$1')
+		.split(',')
+		.map(function (x) {
+			return x.trim();
+		});
 	backgroundColorRgba[3] = '0';
 	this.element.style.backgroundColor = 'rgba(' + backgroundColorRgba.join(',') + ')';
 	backgroundColorRgba.length = 3;
@@ -178,8 +180,8 @@ MediaStreamRenderer.prototype.refresh = function () {
 	elementTop += paddingTop;
 
 	// fix width and height according to padding
-	elementWidth -= (paddingLeft + paddingRight);
-	elementHeight -= (paddingTop + paddingBottom);
+	elementWidth -= paddingLeft + paddingRight;
+	elementHeight -= paddingTop + paddingBottom;
 
 	videoViewWidth = elementWidth;
 	videoViewHeight = elementHeight;
@@ -188,7 +190,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 	if (computedStyle.visibility === 'hidden') {
 		visible = false;
 	} else {
-		visible = !!this.element.offsetHeight;  // Returns 0 if element or any parent is hidden.
+		visible = !!this.element.offsetHeight; // Returns 0 if element or any parent is hidden.
 	}
 
 	// opacity
@@ -198,8 +200,10 @@ MediaStreamRenderer.prototype.refresh = function () {
 	zIndex = parseFloat(computedStyle.zIndex) || parseFloat(this.element.style.zIndex) || 0;
 
 	// mirrored (detect "-webkit-transform: scaleX(-1);" or equivalent)
-	if (computedStyle.transform === 'matrix(-1, 0, 0, 1, 0, 0)' ||
-		computedStyle['-webkit-transform'] === 'matrix(-1, 0, 0, 1, 0, 0)') {
+	if (
+		computedStyle.transform === 'matrix(-1, 0, 0, 1, 0, 0)' ||
+		computedStyle['-webkit-transform'] === 'matrix(-1, 0, 0, 1, 0, 0)'
+	) {
 		mirrored = true;
 	} else {
 		mirrored = false;
@@ -257,8 +261,8 @@ MediaStreamRenderer.prototype.refresh = function () {
 			if (elementRatio >= videoRatio) {
 				videoViewWidth = elementWidth;
 				videoViewHeight = videoViewWidth / videoRatio;
-			// The element has lower width/height ratio than the video.
 			} else if (elementRatio < videoRatio) {
+				// The element has lower width/height ratio than the video.
 				videoViewHeight = elementHeight;
 				videoViewWidth = videoViewHeight * videoRatio;
 			}
@@ -279,29 +283,29 @@ MediaStreamRenderer.prototype.refresh = function () {
 			if (this.videoWidth <= elementWidth && this.videoHeight <= elementHeight) {
 				videoViewHeight = this.videoHeight;
 				videoViewWidth = this.videoWidth;
-			// Same as 'contain'.
 			} else {
-				// The element has higher or equal width/height ratio than the video.
+				// Same as 'contain'.
 				if (elementRatio >= videoRatio) {
+					// The element has higher or equal width/height ratio than the video.
 					videoViewHeight = elementHeight;
 					videoViewWidth = videoViewHeight * videoRatio;
-				// The element has lower width/height ratio than the video.
 				} else if (elementRatio < videoRatio) {
+					// The element has lower width/height ratio than the video.
 					videoViewWidth = elementWidth;
 					videoViewHeight = videoViewWidth / videoRatio;
 				}
 			}
 			break;
 
-		// 'contain'.
 		default:
+			// 'contain'.
 			objectFit = 'contain';
-			// The element has higher or equal width/height ratio than the video.
 			if (elementRatio >= videoRatio) {
+				// The element has higher or equal width/height ratio than the video.
 				videoViewHeight = elementHeight;
 				videoViewWidth = videoViewHeight * videoRatio;
-			// The element has lower width/height ratio than the video.
 			} else if (elementRatio < videoRatio) {
+				// The element has lower width/height ratio than the video.
 				videoViewWidth = elementWidth;
 				videoViewHeight = videoViewWidth / videoRatio;
 			}
@@ -312,7 +316,7 @@ MediaStreamRenderer.prototype.refresh = function () {
 
 	function hash(str) {
 		var hash = 5381,
-		i = str.length;
+			i = str.length;
 
 		while (i) {
 			hash = (hash * 33) ^ str.charCodeAt(--i);
@@ -323,22 +327,22 @@ MediaStreamRenderer.prototype.refresh = function () {
 
 	function nativeRefresh() {
 		var data = {
-			elementLeft: Math.round(elementLeft),
-			elementTop: Math.round(elementTop),
-			elementWidth: Math.round(elementWidth),
-			elementHeight: Math.round(elementHeight),
-			videoViewWidth: Math.round(videoViewWidth),
-			videoViewHeight: Math.round(videoViewHeight),
-			visible: visible,
-			backgroundColor: backgroundColorRgba.join(','),
-			opacity: opacity,
-			zIndex: zIndex,
-			mirrored: mirrored,
-			objectFit: objectFit,
-			clip: clip,
-			borderRadius: borderRadius
-		},
-		newRefreshCached = hash(JSON.stringify(data));
+				elementLeft: Math.round(elementLeft),
+				elementTop: Math.round(elementTop),
+				elementWidth: Math.round(elementWidth),
+				elementHeight: Math.round(elementHeight),
+				videoViewWidth: Math.round(videoViewWidth),
+				videoViewHeight: Math.round(videoViewHeight),
+				visible: visible,
+				backgroundColor: backgroundColorRgba.join(','),
+				opacity: opacity,
+				zIndex: zIndex,
+				mirrored: mirrored,
+				objectFit: objectFit,
+				clip: clip,
+				borderRadius: borderRadius
+			},
+			newRefreshCached = hash(JSON.stringify(data));
 
 		if (newRefreshCached === self.refreshCached) {
 			return;
@@ -351,7 +355,6 @@ MediaStreamRenderer.prototype.refresh = function () {
 		exec(null, null, 'iosrtcPlugin', 'MediaStreamRenderer_refresh', [this.id, data]);
 	}
 };
-
 
 MediaStreamRenderer.prototype.close = function () {
 	debug('close()');
@@ -368,11 +371,9 @@ MediaStreamRenderer.prototype.close = function () {
 	}
 };
 
-
 /**
  * Private API.
  */
-
 
 function onEvent(data) {
 	var type = data.type,
@@ -395,14 +396,13 @@ function onEvent(data) {
 	}
 }
 
-
 function getElementPositionAndSize() {
 	var rect = this.element.getBoundingClientRect();
 
 	return {
-		left:   rect.left + this.element.clientLeft,
-		top:    rect.top + this.element.clientTop,
-		width:  this.element.clientWidth,
+		left: rect.left + this.element.clientLeft,
+		top: rect.top + this.element.clientTop,
+		width: this.element.clientWidth,
 		height: this.element.clientHeight
 	};
 }

--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -3,17 +3,14 @@
  */
 module.exports = MediaStreamTrack;
 
-
 /**
  * Spec: http://w3c.github.io/mediacapture-main/#mediastreamtrack
  */
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:MediaStreamTrack'),
+var debug = require('debug')('iosrtc:MediaStreamTrack'),
 	exec = require('cordova/exec'),
 	enumerateDevices = require('./enumerateDevices'),
 	MediaTrackCapabilities = require('./MediaTrackCapabilities'),
@@ -24,7 +21,7 @@ var
 var originalMediaStreamTrack = window.MediaStreamTrack || function dummyMediaStreamTrack() {};
 
 function newMediaStreamTrackId() {
-   return window.crypto.getRandomValues(new Uint32Array(4)).join('-');
+	return window.crypto.getRandomValues(new Uint32Array(4)).join('-');
 }
 
 function MediaStreamTrack(dataFromEvent) {
@@ -40,10 +37,10 @@ function MediaStreamTrack(dataFromEvent) {
 	EventTarget.call(this);
 
 	// Public atributes.
-	this.id = dataFromEvent.id;  // NOTE: It's a string.
+	this.id = dataFromEvent.id; // NOTE: It's a string.
 	this.kind = dataFromEvent.kind;
 	this.label = dataFromEvent.label;
-	this.muted = false;  // TODO: No "muted" property in ObjC API.
+	this.muted = false; // TODO: No "muted" property in ObjC API.
 	this.readyState = dataFromEvent.readyState;
 
 	// Private attributes.
@@ -85,18 +82,17 @@ MediaStreamTrack.prototype.applyConstraints = function () {
 };
 
 MediaStreamTrack.prototype.clone = function () {
-
 	var newTrackId = newMediaStreamTrackId();
 
 	exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_clone', [this.id, newTrackId]);
 
 	return new MediaStreamTrack({
- 		id: newTrackId,
- 		kind: this.kind,
- 		label: this.label,
- 		readyState: this.readyState,
- 		enabled: this.enabled
- 	});
+		id: newTrackId,
+		kind: this.kind,
+		label: this.label,
+		readyState: this.readyState,
+		enabled: this.enabled
+	});
 };
 
 MediaStreamTrack.prototype.getCapabilities = function () {
@@ -121,14 +117,11 @@ MediaStreamTrack.prototype.stop = function () {
 	exec(null, null, 'iosrtcPlugin', 'MediaStreamTrack_stop', [this.id]);
 };
 
-
 // TODO: API methods and events.
-
 
 /**
  * Class methods.
  */
-
 
 MediaStreamTrack.getSources = function () {
 	debug('getSources()');
@@ -136,11 +129,9 @@ MediaStreamTrack.getSources = function () {
 	return enumerateDevices.apply(this, arguments);
 };
 
-
 /**
  * Private API.
  */
-
 
 function onEvent(data) {
 	var type = data.type;

--- a/js/RTCDTMFSender.js
+++ b/js/RTCDTMFSender.js
@@ -3,20 +3,16 @@
  */
 module.exports = RTCDTMFSender;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:RTCDTMFSender'),
+var debug = require('debug')('iosrtc:RTCDTMFSender'),
 	debugerror = require('debug')('iosrtc:ERROR:RTCDTMFSender'),
 	exec = require('cordova/exec'),
-	randomNumber = require('random-number').generator({min: 10000, max: 99999, integer: true}),
+	randomNumber = require('random-number').generator({ min: 10000, max: 99999, integer: true }),
 	EventTarget = require('./EventTarget');
 
-
 debugerror.log = console.warn.bind(console);
-
 
 function RTCDTMFSender(peerConnection, track) {
 	var self = this;
@@ -41,8 +37,11 @@ function RTCDTMFSender(peerConnection, track) {
 		onEvent.call(self, data);
 	}
 
-	exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_createDTMFSender', [this.peerConnection.pcId, this.dsId, this._track.id]);
-
+	exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_createDTMFSender', [
+		this.peerConnection.pcId,
+		this.dsId,
+		this._track.id
+	]);
 }
 
 RTCDTMFSender.prototype = Object.create(EventTarget.prototype);
@@ -55,13 +54,11 @@ Object.defineProperty(RTCDTMFSender.prototype, 'canInsertDTMF', {
 	}
 });
 
-
 Object.defineProperty(RTCDTMFSender.prototype, 'track', {
 	get: function () {
 		return this._track;
 	}
 });
-
 
 Object.defineProperty(RTCDTMFSender.prototype, 'duration', {
 	get: function () {
@@ -69,20 +66,17 @@ Object.defineProperty(RTCDTMFSender.prototype, 'duration', {
 	}
 });
 
-
 Object.defineProperty(RTCDTMFSender.prototype, 'interToneGap', {
 	get: function () {
 		return this._interToneGap;
 	}
 });
 
-
 Object.defineProperty(RTCDTMFSender.prototype, 'toneBuffer', {
 	get: function () {
 		return this._toneBuffer;
 	}
 });
-
 
 RTCDTMFSender.prototype.insertDTMF = function (tones, duration, interToneGap) {
 	if (isClosed.call(this)) {
@@ -104,19 +98,22 @@ RTCDTMFSender.prototype.insertDTMF = function (tones, duration, interToneGap) {
 		onEvent.call(self, data);
 	}
 
-	exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDTMFSender_insertDTMF', [this.peerConnection.pcId, this.dsId, tones, this._duration, this._interToneGap]);
+	exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDTMFSender_insertDTMF', [
+		this.peerConnection.pcId,
+		this.dsId,
+		tones,
+		this._duration,
+		this._interToneGap
+	]);
 };
-
 
 /**
  * Private API.
  */
 
-
 function isClosed() {
 	return this.peerConnection.signalingState === 'closed';
 }
-
 
 function onEvent(data) {
 	var type = data.type,

--- a/js/RTCDataChannel.js
+++ b/js/RTCDataChannel.js
@@ -3,20 +3,16 @@
  */
 module.exports = RTCDataChannel;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:RTCDataChannel'),
+var debug = require('debug')('iosrtc:RTCDataChannel'),
 	debugerror = require('debug')('iosrtc:ERROR:RTCDataChannel'),
 	exec = require('cordova/exec'),
-	randomNumber = require('random-number').generator({min: 10000, max: 99999, integer: true}),
+	randomNumber = require('random-number').generator({ min: 10000, max: 99999, integer: true }),
 	EventTarget = require('./EventTarget');
 
-
 debugerror.log = console.warn.bind(console);
-
 
 function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 	var self = this;
@@ -34,7 +30,10 @@ function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 
 		options = options || {};
 
-		if (options.hasOwnProperty('maxPacketLifeTime') && options.hasOwnProperty('maxRetransmits')) {
+		if (
+			options.hasOwnProperty('maxPacketLifeTime') &&
+			options.hasOwnProperty('maxRetransmits')
+		) {
 			throw new SyntaxError('both maxPacketLifeTime and maxRetransmits can not be present');
 		}
 
@@ -45,15 +44,21 @@ function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 			// TODO:
 			//   https://code.google.com/p/webrtc/issues/detail?id=4618
 			if (options.id > 1023) {
-				throw new SyntaxError('id cannot be greater than 1023 (https://code.google.com/p/webrtc/issues/detail?id=4614)');
+				throw new SyntaxError(
+					'id cannot be greater than 1023 (https://code.google.com/p/webrtc/issues/detail?id=4614)'
+				);
 			}
 		}
 
 		// Public atributes.
 		this.label = label;
 		this.ordered = options.hasOwnProperty('ordered') ? !!options.ordered : true;
-		this.maxPacketLifeTime = options.hasOwnProperty('maxPacketLifeTime') ? Number(options.maxPacketLifeTime) : null;
-		this.maxRetransmits = options.hasOwnProperty('maxRetransmits') ? Number(options.maxRetransmits) : null;
+		this.maxPacketLifeTime = options.hasOwnProperty('maxPacketLifeTime')
+			? Number(options.maxPacketLifeTime)
+			: null;
+		this.maxRetransmits = options.hasOwnProperty('maxRetransmits')
+			? Number(options.maxRetransmits)
+			: null;
 		this.protocol = options.hasOwnProperty('protocol') ? String(options.protocol) : '';
 		this.negotiated = options.hasOwnProperty('negotiated') ? !!options.negotiated : false;
 		this.id = options.hasOwnProperty('id') ? Number(options.id) : undefined;
@@ -65,9 +70,14 @@ function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 		this.peerConnection = peerConnection;
 		this.dcId = randomNumber();
 
-		exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_createDataChannel', [this.peerConnection.pcId, this.dcId, label, options]);
-	// Created via pc.ondatachannel.
+		exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_createDataChannel', [
+			this.peerConnection.pcId,
+			this.dcId,
+			label,
+			options
+		]);
 	} else {
+		// Created via pc.ondatachannel.
 		debug('new() | [dataFromEvent:%o]', dataFromEvent);
 
 		// Public atributes.
@@ -86,14 +96,17 @@ function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 		this.peerConnection = peerConnection;
 		this.dcId = dataFromEvent.dcId;
 
-		exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_setListener', [this.peerConnection.pcId, this.dcId]);
+		exec(onResultOK, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_setListener', [
+			this.peerConnection.pcId,
+			this.dcId
+		]);
 	}
 
 	function onResultOK(data) {
 		if (data.type) {
 			onEvent.call(self, data);
-		// Special handler for received binary mesage.
 		} else {
+			// Special handler for received binary message.
 			onEvent.call(self, {
 				type: 'message',
 				message: data
@@ -117,7 +130,6 @@ Object.defineProperty(RTCDataChannel.prototype, 'binaryType', {
 	}
 });
 
-
 RTCDataChannel.prototype.send = function (data) {
 	if (isClosed.call(this) || this.readyState !== 'open') {
 		return;
@@ -130,9 +142,17 @@ RTCDataChannel.prototype.send = function (data) {
 	}
 
 	if (typeof data === 'string' || data instanceof String) {
-		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_sendString', [this.peerConnection.pcId, this.dcId, data]);
+		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_sendString', [
+			this.peerConnection.pcId,
+			this.dcId,
+			data
+		]);
 	} else if (window.ArrayBuffer && data instanceof window.ArrayBuffer) {
-		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_sendBinary', [this.peerConnection.pcId, this.dcId, data]);
+		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_sendBinary', [
+			this.peerConnection.pcId,
+			this.dcId,
+			data
+		]);
 	} else if (
 		(window.Int8Array && data instanceof window.Int8Array) ||
 		(window.Uint8Array && data instanceof window.Uint8Array) ||
@@ -145,12 +165,15 @@ RTCDataChannel.prototype.send = function (data) {
 		(window.Float64Array && data instanceof window.Float64Array) ||
 		(window.DataView && data instanceof window.DataView)
 	) {
-		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_sendBinary', [this.peerConnection.pcId, this.dcId, data.buffer]);
+		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_sendBinary', [
+			this.peerConnection.pcId,
+			this.dcId,
+			data.buffer
+		]);
 	} else {
 		throw new Error('invalid data type');
 	}
 };
-
 
 RTCDataChannel.prototype.close = function () {
 	if (isClosed.call(this)) {
@@ -161,19 +184,23 @@ RTCDataChannel.prototype.close = function () {
 
 	this.readyState = 'closing';
 
-	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_close', [this.peerConnection.pcId, this.dcId]);
+	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_RTCDataChannel_close', [
+		this.peerConnection.pcId,
+		this.dcId
+	]);
 };
-
 
 /**
  * Private API.
  */
 
-
 function isClosed() {
-	return this.readyState === 'closed' || this.readyState === 'closing' || this.peerConnection.signalingState === 'closed';
+	return (
+		this.readyState === 'closed' ||
+		this.readyState === 'closing' ||
+		this.peerConnection.signalingState === 'closed'
+	);
 }
-
 
 function onEvent(data) {
 	var type = data.type,
@@ -220,7 +247,10 @@ function onEvent(data) {
 		case 'bufferedamount':
 			this.bufferedAmount = data.bufferedAmount;
 
-			if (this.bufferedAmountLowThreshold > 0 && this.bufferedAmountLowThreshold > this.bufferedAmount) {
+			if (
+				this.bufferedAmountLowThreshold > 0 &&
+				this.bufferedAmountLowThreshold > this.bufferedAmount
+			) {
 				event = new Event('bufferedamountlow');
 				event.bufferedAmount = this.bufferedAmount;
 				this.dispatchEvent(event);

--- a/js/RTCIceCandidate.js
+++ b/js/RTCIceCandidate.js
@@ -3,8 +3,6 @@
  */
 module.exports = RTCIceCandidate;
 
-
-
 /**
 * RFC-5245: http://tools.ietf.org/html/rfc5245#section-15.1
 *
@@ -62,102 +60,102 @@ module.exports = RTCIceCandidate;
 
 var candidateToJson = (function () {
 	var candidateFieldName = {
-	  FOUNDATION: 'foundation',
-	  COMPONENT_ID: 'componentId',
-	  TRANSPORT: 'transport',
-	  PRIORITY: 'priority',
-	  CONNECTION_ADDRESS: 'connectionAddress',
-	  PORT: 'port',
-	  CANDIDATE_TYPE: 'candidateType',
-	  REMOTE_CANDIDATE_ADDRESS: 'remoteConnectionAddress',
-	  REMOTE_CANDIDATE_PORT: 'remotePort'
+		FOUNDATION: 'foundation',
+		COMPONENT_ID: 'componentId',
+		TRANSPORT: 'transport',
+		PRIORITY: 'priority',
+		CONNECTION_ADDRESS: 'connectionAddress',
+		PORT: 'port',
+		CANDIDATE_TYPE: 'candidateType',
+		REMOTE_CANDIDATE_ADDRESS: 'remoteConnectionAddress',
+		REMOTE_CANDIDATE_PORT: 'remotePort'
 	};
 
 	var candidateType = {
-	  HOST: 'host',
-	  SRFLX: 'srflx',
-	  PRFLX: 'prflx',
-	  RELAY: 'relay'
+		HOST: 'host',
+		SRFLX: 'srflx',
+		PRFLX: 'prflx',
+		RELAY: 'relay'
 	};
 
 	var transport = {
-	  TCP: 'TCP',
-	  UDP: 'UDP'
+		TCP: 'TCP',
+		UDP: 'UDP'
 	};
 
 	var IPV4SEG = '(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])';
-	var IPV4ADDR = '(?:' + IPV4SEG + '\\.){3}' + IPV4SEG + '';
+	var IPV4ADDR = `(?:${IPV4SEG}\\.){3}${IPV4SEG}`;
 	var IPV6SEG = '[0-9a-fA-F]{1,4}';
 	var IPV6ADDR =
-	    '(?:' + IPV6SEG + ':){7,7}' + IPV6SEG + '|' +				// 1:2:3:4:5:6:7:8
-	    '(?:' + IPV6SEG + ':){1,7}:|' +								// 1::                              1:2:3:4:5:6:7::
-	    '(?:' + IPV6SEG + ':){1,6}:' + IPV6SEG + '|' +				// 1::8             1:2:3:4:5:6::8  1:2:3:4:5:6::8
-	    '(?:' + IPV6SEG + ':){1,5}(?::' + IPV6SEG + '){1,2}|' +		// 1::7:8           1:2:3:4:5::7:8  1:2:3:4:5::8
-	    '(?:' + IPV6SEG + ':){1,4}(?::' + IPV6SEG + '){1,3}|' +		// 1::6:7:8         1:2:3:4::6:7:8  1:2:3:4::8
-	    '(?:' + IPV6SEG + ':){1,3}(?::' + IPV6SEG + '){1,4}|' +		// 1::5:6:7:8       1:2:3::5:6:7:8  1:2:3::8
-	    '(?:' + IPV6SEG + ':){1,2}(?::' + IPV6SEG + '){1,5}|' +		// 1::4:5:6:7:8     1:2::4:5:6:7:8  1:2::8
-	    '' + IPV6SEG + ':(?:(?::' + IPV6SEG + '){1,6})|' +			// 1::3:4:5:6:7:8   1::3:4:5:6:7:8  1::8
-	    ':(?:(?::' + IPV6SEG + '){1,7}|:)|' +						// ::2:3:4:5:6:7:8  ::2:3:4:5:6:7:8 ::8       ::
-	    'fe80:(?::' + IPV6SEG + '){0,4}%[0-9a-zA-Z]{1,}|' +			// fe80::7:8%eth0   fe80::7:8%1     (link-local IPv6 addresses with zone index)
-	    '::(?:ffff(?::0{1,4}){0,1}:){0,1}' + IPV4ADDR + '|' +		// ::255.255.255.255   ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
-	    '(?:' + IPV6SEG + ':){1,4}:' + IPV4ADDR + '';				// 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
+		`(?:${IPV6SEG}:){7,7}${IPV6SEG}|` + // 1:2:3:4:5:6:7:8
+		`(?:${IPV6SEG}:){1,7}:|` + // 1::                              1:2:3:4:5:6:7::
+		`(?:${IPV6SEG}:){1,6}:${IPV6SEG}|` + // 1::8             1:2:3:4:5:6::8  1:2:3:4:5:6::8
+		`(?:${IPV6SEG}:){1,5}(?::${IPV6SEG}){1,2}|` + // 1::7:8           1:2:3:4:5::7:8  1:2:3:4:5::8
+		`(?:${IPV6SEG}:){1,4}(?::${IPV6SEG}){1,3}|` + // 1::6:7:8         1:2:3:4::6:7:8  1:2:3:4::8
+		`(?:${IPV6SEG}:){1,3}(?::${IPV6SEG}){1,4}|` + // 1::5:6:7:8       1:2:3::5:6:7:8  1:2:3::8
+		`(?:${IPV6SEG}:){1,2}(?::${IPV6SEG}){1,5}|` + // 1::4:5:6:7:8     1:2::4:5:6:7:8  1:2::8
+		`${IPV6SEG}:(?:(?::${IPV6SEG}){1,6})|` + // 1::3:4:5:6:7:8   1::3:4:5:6:7:8  1::8
+		`:(?:(?::${IPV6SEG}){1,7}|:)|` + // ::2:3:4:5:6:7:8  ::2:3:4:5:6:7:8 ::8       ::
+		`fe80:(?::${IPV6SEG}){0,4}%[0-9a-zA-Z]{1,}|` + // fe80::7:8%eth0   fe80::7:8%1     (link-local IPv6 addresses with zone index)
+		`::(?:ffff(?::0{1,4}){0,1}:){0,1}${IPV4ADDR}|` + // ::255.255.255.255   ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
+		`(?:${IPV6SEG}:){1,4}:${IPV4ADDR}`; // 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
 
-	var TOKEN = '[0-9a-zA-Z\\-\\.!\\%\\*_\\+\\`\\\'\\~]+';
+	var TOKEN = "[0-9a-zA-Z\\-\\.!\\%\\*_\\+\\`\\'\\~]+";
 
 	var CANDIDATE_TYPE = '';
 	Object.keys(candidateType).forEach(function (key) {
-	  CANDIDATE_TYPE += candidateType[key] + '|';
+		CANDIDATE_TYPE += candidateType[key] + '|';
 	});
 	CANDIDATE_TYPE += TOKEN;
 
 	var pattern = {
-	  COMPONENT_ID: '[0-9]{1,5}',
-	  FOUNDATION: '[a-zA-Z0-9\\+\\/\\-]+',
-	  PRIORITY: '[0-9]{1,10}',
-	  TRANSPORT: transport.UPD + '|' + TOKEN,
-	  CONNECTION_ADDRESS: IPV4ADDR + '|' + IPV6ADDR,
-	  PORT: '[0-9]{1,5}',
-	  CANDIDATE_TYPE: CANDIDATE_TYPE
+		COMPONENT_ID: '[0-9]{1,5}',
+		FOUNDATION: '[a-zA-Z0-9\\+\\/\\-]+',
+		PRIORITY: '[0-9]{1,10}',
+		TRANSPORT: transport.UPD + '|' + TOKEN,
+		CONNECTION_ADDRESS: IPV4ADDR + '|' + IPV6ADDR,
+		PORT: '[0-9]{1,5}',
+		CANDIDATE_TYPE: CANDIDATE_TYPE
 	};
 
 	return function candidateToJson(iceCandidate) {
-	    var iceCandidateJson = null;
+		var iceCandidateJson = null;
 
-	    if (iceCandidate && typeof iceCandidate === 'string') {
-	      var ICE_CANDIDATE_PATTERN = new RegExp(
-	        'candidate:(' + pattern.FOUNDATION + ')' +      // 10
-	        '\\s(' + pattern.COMPONENT_ID + ')' +           // 1
-	        '\\s(' + pattern.TRANSPORT + ')' +              // UDP
-	        '\\s(' + pattern.PRIORITY + ')' +               // 1845494271
-	        '\\s(' + pattern.CONNECTION_ADDRESS + ')' +     // 13.93.107.159
-	        '\\s(' + pattern.PORT + ')' +                   // 53705
-	        '\\s' +
-	        'typ' +
-	        '\\s(' + pattern.CANDIDATE_TYPE + ')' +         // typ prflx
-	        '(?:\\s' +
-	        'raddr' +
-	        '\\s(' + pattern.CONNECTION_ADDRESS + ')' +     // raddr 10.1.221.7
-	        '\\s' +
-	        'rport' +
-	        '\\s(' + pattern.PORT + '))?'                    // rport 54805
-	      );
+		if (iceCandidate && typeof iceCandidate === 'string') {
+			var ICE_CANDIDATE_PATTERN = new RegExp(
+				`candidate:(${pattern.FOUNDATION})` + // 10
+					`\\s(${pattern.COMPONENT_ID})` + // 1
+					`\\s(${pattern.TRANSPORT})` + // UDP
+					`\\s(${pattern.PRIORITY})` + // 1845494271
+					`\\s(${pattern.CONNECTION_ADDRESS})` + // 13.93.107.159
+					`\\s(${pattern.PORT})` + // 53705
+					'\\s' +
+					'typ' +
+					`\\s(${pattern.CANDIDATE_TYPE})` + // typ prflx
+					'(?:\\s' +
+					'raddr' +
+					`\\s(${pattern.CONNECTION_ADDRESS})` + // raddr 10.1.221.7
+					'\\s' +
+					'rport' +
+					`\\s(${pattern.PORT}))?` // rport 54805
+			);
 
-	      var iceCandidateFields = iceCandidate.match(ICE_CANDIDATE_PATTERN);
-	      if (iceCandidateFields) {
-	        iceCandidateJson = {};
-	        Object.keys(candidateFieldName).forEach(function (key, i) {
-	          // i+1 because match returns the entire match result
-	          // and the parentheses-captured matched results.
-	          if (iceCandidateFields.length > (i + 1) && iceCandidateFields[i + 1]) {
-	            iceCandidateJson[candidateFieldName[key]] = iceCandidateFields[i + 1];
-	          }
-	        });
-	      }
-	    }
+			var iceCandidateFields = iceCandidate.match(ICE_CANDIDATE_PATTERN);
+			if (iceCandidateFields) {
+				iceCandidateJson = {};
+				Object.keys(candidateFieldName).forEach(function (key, i) {
+					// i+1 because match returns the entire match result
+					// and the parentheses-captured matched results.
+					if (iceCandidateFields.length > i + 1 && iceCandidateFields[i + 1]) {
+						iceCandidateJson[candidateFieldName[key]] = iceCandidateFields[i + 1];
+					}
+				});
+			}
+		}
 
-	    return iceCandidateJson;
+		return iceCandidateJson;
 	};
-}());
+})();
 
 // See https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/RTCIceCandidate
 function RTCIceCandidate(data) {

--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -3,15 +3,13 @@
  */
 module.exports = RTCPeerConnection;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:RTCPeerConnection'),
+var debug = require('debug')('iosrtc:RTCPeerConnection'),
 	debugerror = require('debug')('iosrtc:ERROR:RTCPeerConnection'),
 	exec = require('cordova/exec'),
-	randomNumber = require('random-number').generator({min: 10000, max: 99999, integer: true}),
+	randomNumber = require('random-number').generator({ min: 10000, max: 99999, integer: true }),
 	EventTarget = require('./EventTarget'),
 	RTCSessionDescription = require('./RTCSessionDescription'),
 	RTCIceCandidate = require('./RTCIceCandidate'),
@@ -52,7 +50,11 @@ function RTCPeerConnection(pcConfig, pcConstraints) {
 	// NotSupportedError: The adapter.js addTrack, addStream polyfill only supports a single stream which is associated with the specified track.
 	Object.defineProperty(this, 'addTrack', RTCPeerConnection.prototype_descriptor.addTrack);
 	Object.defineProperty(this, 'addStream', RTCPeerConnection.prototype_descriptor.addStream);
-	Object.defineProperty(this, 'getLocalStreams', RTCPeerConnection.prototype_descriptor.getLocalStreams);
+	Object.defineProperty(
+		this,
+		'getLocalStreams',
+		RTCPeerConnection.prototype_descriptor.getLocalStreams
+	);
 
 	// Public atributes.
 	this._localDescription = null;
@@ -73,54 +75,58 @@ function RTCPeerConnection(pcConfig, pcConstraints) {
 		onEvent.call(self, data);
 	}
 
-	exec(onResultOK, null, 'iosrtcPlugin', 'new_RTCPeerConnection', [this.pcId, this.pcConfig, pcConstraints]);
+	exec(onResultOK, null, 'iosrtcPlugin', 'new_RTCPeerConnection', [
+		this.pcId,
+		this.pcConfig,
+		pcConstraints
+	]);
 }
 
 RTCPeerConnection.prototype = Object.create(EventTarget.prototype);
 RTCPeerConnection.prototype.constructor = RTCPeerConnection;
 
 Object.defineProperties(RTCPeerConnection.prototype, {
-	'localDescription': {
+	localDescription: {
 		// Fix webrtc-adapter TypeError: Attempting to change the getter of an unconfigurable property.
 		configurable: true,
-		get: function() {
+		get: function () {
 			return this._localDescription;
 		}
 	},
-	'connectionState': {
-		get: function() {
+	connectionState: {
+		get: function () {
 			return this.iceConnectionState;
 		}
 	},
-	'onicecandidate': {
+	onicecandidate: {
 		// Fix webrtc-adapter TypeError: Attempting to change the getter of an unconfigurable property.
 		configurable: true,
 		set: function (callback) {
 			return this.addEventListener('icecandidate', callback);
 		}
 	},
-	'onaddstream': {
+	onaddstream: {
 		// Fix webrtc-adapter TypeError: Attempting to change the getter of an unconfigurable property.
 		configurable: true,
 		set: function (callback) {
 			return this.addEventListener('addstream', callback);
 		}
 	},
-	'ontrack': {
+	ontrack: {
 		// Fix webrtc-adapter TypeError: Attempting to change the getter of an unconfigurable property.
 		configurable: true,
 		set: function (callback) {
 			return this.addEventListener('track', callback);
 		}
 	},
-	'oniceconnectionstatechange': {
+	oniceconnectionstatechange: {
 		// Fix webrtc-adapter TypeError: Attempting to change the getter of an unconfigurable property.
 		configurable: true,
 		set: function (callback) {
 			return this.addEventListener('iceconnectionstatechange', callback);
 		}
 	},
-	'onnegotiationneeded': {
+	onnegotiationneeded: {
 		// Fix webrtc-adapter TypeError: Attempting to change the getter of an unconfigurable property.
 		configurable: true,
 		set: function (callback) {
@@ -130,7 +136,6 @@ Object.defineProperties(RTCPeerConnection.prototype, {
 });
 
 RTCPeerConnection.prototype.createOffer = function (options) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
 	Errors.detectDeprecatedCallbaksUsage('RTCPeerConnection.prototype.createOffer', arguments);
@@ -164,13 +169,14 @@ RTCPeerConnection.prototype.createOffer = function (options) {
 			reject(new global.DOMException(error));
 		}
 
-		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_createOffer', [self.pcId, options]);
+		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_createOffer', [
+			self.pcId,
+			options
+		]);
 	});
 };
 
-
 RTCPeerConnection.prototype.createAnswer = function (options) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
 	Errors.detectDeprecatedCallbaksUsage('RTCPeerConnection.prototype.createAnswer', arguments);
@@ -204,15 +210,20 @@ RTCPeerConnection.prototype.createAnswer = function (options) {
 			reject(new global.DOMException(error));
 		}
 
-		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_createAnswer', [self.pcId, options]);
+		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_createAnswer', [
+			self.pcId,
+			options
+		]);
 	});
 };
 
 RTCPeerConnection.prototype.setLocalDescription = function (desc) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
-	Errors.detectDeprecatedCallbaksUsage('RTCPeerConnection.prototype.setLocalDescription', arguments);
+	Errors.detectDeprecatedCallbaksUsage(
+		'RTCPeerConnection.prototype.setLocalDescription',
+		arguments
+	);
 
 	var self = this;
 
@@ -250,18 +261,25 @@ RTCPeerConnection.prototype.setLocalDescription = function (desc) {
 			}
 
 			debugerror('setLocalDescription() | failure: %s', error);
-			reject(new Errors.InvalidSessionDescriptionError('setLocalDescription() failed: ' + error));
+			reject(
+				new Errors.InvalidSessionDescriptionError('setLocalDescription() failed: ' + error)
+			);
 		}
 
-		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_setLocalDescription', [self.pcId, desc]);
+		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_setLocalDescription', [
+			self.pcId,
+			desc
+		]);
 	});
 };
 
 RTCPeerConnection.prototype.setRemoteDescription = function (desc) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
-	Errors.detectDeprecatedCallbaksUsage('RTCPeerConnection.prototype.setRemoteDescription', arguments);
+	Errors.detectDeprecatedCallbaksUsage(
+		'RTCPeerConnection.prototype.setRemoteDescription',
+		arguments
+	);
 
 	var self = this;
 
@@ -301,15 +319,19 @@ RTCPeerConnection.prototype.setRemoteDescription = function (desc) {
 			}
 
 			debugerror('setRemoteDescription() | failure: %s', error);
-			reject(new Errors.InvalidSessionDescriptionError('setRemoteDescription() failed: ' + error));
+			reject(
+				new Errors.InvalidSessionDescriptionError('setRemoteDescription() failed: ' + error)
+			);
 		}
 
-		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_setRemoteDescription', [self.pcId, desc]);
+		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_setRemoteDescription', [
+			self.pcId,
+			desc
+		]);
 	});
 };
 
 RTCPeerConnection.prototype.addIceCandidate = function (candidate) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
 	Errors.detectDeprecatedCallbaksUsage('RTCPeerConnection.prototype.addIceCandidate', arguments);
@@ -326,7 +348,11 @@ RTCPeerConnection.prototype.addIceCandidate = function (candidate) {
 
 	if (typeof candidate !== 'object') {
 		return new Promise(function (resolve, reject) {
-			reject(new global.DOMException('addIceCandidate() must be called with a RTCIceCandidate instance or RTCIceCandidateInit object as argument'));
+			reject(
+				new global.DOMException(
+					'addIceCandidate() must be called with a RTCIceCandidate instance or RTCIceCandidateInit object as argument'
+				)
+			);
 		});
 	}
 
@@ -356,7 +382,10 @@ RTCPeerConnection.prototype.addIceCandidate = function (candidate) {
 			reject(new global.DOMException('addIceCandidate() failed'));
 		}
 
-		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_addIceCandidate', [self.pcId, candidate]);
+		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_addIceCandidate', [
+			self.pcId,
+			candidate
+		]);
 	});
 };
 
@@ -381,7 +410,6 @@ RTCPeerConnection.prototype.getLocalStreams = function () {
 
 	return streams;
 };
-
 
 RTCPeerConnection.prototype.getRemoteStreams = function () {
 	debug('getRemoteStreams()');
@@ -441,20 +469,23 @@ RTCPeerConnection.prototype.getTransceivers = function () {
 	var transceivers = [];
 
 	this.getReceivers().map(function (receiver) {
-		transceivers.push(new RTCRtpTransceiver({
-			receiver: receiver
-		}));
+		transceivers.push(
+			new RTCRtpTransceiver({
+				receiver: receiver
+			})
+		);
 	});
 
 	this.getSenders().map(function (sender) {
-		transceivers.push(new RTCRtpTransceiver({
-			sender: sender
-		}));
+		transceivers.push(
+			new RTCRtpTransceiver({
+				sender: sender
+			})
+		);
 	});
 
 	return transceivers;
 };
-
 
 RTCPeerConnection.prototype.addTrack = function (track, stream) {
 	var id;
@@ -486,7 +517,11 @@ RTCPeerConnection.prototype.addTrack = function (track, stream) {
 			if (!stream || (stream && stream.id === id)) {
 				stream = this.localStreams[id];
 				stream.addTrack(track);
-				exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addTrack', [this.pcId, track.id, id]);
+				exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addTrack', [
+					this.pcId,
+					track.id,
+					id
+				]);
 				break;
 			}
 		}
@@ -498,17 +533,14 @@ RTCPeerConnection.prototype.addTrack = function (track, stream) {
 	}
 
 	this.localTracks[track.id] = track;
-	
+
 	return new RTCRtpSender({
 		track: track
 	});
 };
 
 RTCPeerConnection.prototype.removeTrack = function (sender) {
-	var id,
-		track,
-		stream,
-		hasTrack;
+	var id, track, stream, hasTrack;
 
 	if (!(sender instanceof RTCRtpSender)) {
 		throw new Error('removeTrack() must be called with a RTCRtpSender instance as argument');
@@ -523,12 +555,16 @@ RTCPeerConnection.prototype.removeTrack = function (sender) {
 	for (id in this.localStreams) {
 		if (this.localStreams.hasOwnProperty(id)) {
 			// Check if track is belong to stream
-			hasTrack = (this.localStreams[id].getTracks().filter(matchLocalTrack).length > 0);
+			hasTrack = this.localStreams[id].getTracks().filter(matchLocalTrack).length > 0;
 
 			if (hasTrack) {
 				stream = this.localStreams[id];
 				stream.removeTrack(track);
-				exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_removeTrack', [this.pcId, track.id, stream.id]);
+				exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_removeTrack', [
+					this.pcId,
+					track.id,
+					stream.id
+				]);
 				delete this.localTracks[track.id];
 				break;
 			}
@@ -540,7 +576,11 @@ RTCPeerConnection.prototype.removeTrack = function (sender) {
 		for (id in this.localTracks) {
 			if (this.localTracks.hasOwnProperty(id)) {
 				if (track.id === id) {
-					exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_removeTrack', [this.pcId, track.id, null]);	
+					exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_removeTrack', [
+						this.pcId,
+						track.id,
+						null
+					]);
 					delete this.localTracks[track.id];
 				}
 			}
@@ -553,7 +593,6 @@ RTCPeerConnection.prototype.getStreamById = function (id) {
 
 	return this.localStreams[id] || this.remoteStreams[id] || null;
 };
-
 
 RTCPeerConnection.prototype.addStream = function (stream) {
 	var self = this;
@@ -585,7 +624,6 @@ RTCPeerConnection.prototype.addStream = function (stream) {
 	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addStream', [this.pcId, stream.id]);
 };
 
-
 RTCPeerConnection.prototype.removeStream = function (stream) {
 	var self = this;
 
@@ -613,7 +651,6 @@ RTCPeerConnection.prototype.removeStream = function (stream) {
 	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_removeStream', [this.pcId, stream.id]);
 };
 
-
 RTCPeerConnection.prototype.createDataChannel = function (label, options) {
 	if (isClosed.call(this)) {
 		throw new Errors.InvalidStateError('peerconnection is closed');
@@ -623,7 +660,6 @@ RTCPeerConnection.prototype.createDataChannel = function (label, options) {
 
 	return new RTCDataChannel(this, label, options);
 };
-
 
 RTCPeerConnection.prototype.createDTMFSender = function (track) {
 	if (isClosed.call(this)) {
@@ -636,7 +672,6 @@ RTCPeerConnection.prototype.createDTMFSender = function (track) {
 };
 
 RTCPeerConnection.prototype.getStats = function (selector) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
 	Errors.detectDeprecatedCallbaksUsage('RTCPeerConnection.prototype.getStats', arguments);
@@ -644,7 +679,9 @@ RTCPeerConnection.prototype.getStats = function (selector) {
 	var self = this;
 
 	if (selector && !(selector instanceof MediaStreamTrack)) {
-		throw new Error('getStats() must be called with null or a valid MediaStreamTrack instance as argument');
+		throw new Error(
+			'getStats() must be called with null or a valid MediaStreamTrack instance as argument'
+		);
 	}
 
 	if (isClosed.call(this)) {
@@ -675,7 +712,10 @@ RTCPeerConnection.prototype.getStats = function (selector) {
 			reject(new global.DOMException(error));
 		}
 
-		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_getStats', [self.pcId, selector ? selector.id : null]);
+		exec(onResultOK, onResultError, 'iosrtcPlugin', 'RTCPeerConnection_getStats', [
+			self.pcId,
+			selector ? selector.id : null
+		]);
 	});
 };
 
@@ -690,7 +730,9 @@ RTCPeerConnection.prototype.close = function () {
 };
 
 // Save current RTCPeerConnection.prototype
-RTCPeerConnection.prototype_descriptor = Object.getOwnPropertyDescriptors(RTCPeerConnection.prototype);
+RTCPeerConnection.prototype_descriptor = Object.getOwnPropertyDescriptors(
+	RTCPeerConnection.prototype
+);
 
 /**
  * Private API.
@@ -703,7 +745,9 @@ function fixPcConfig(pcConfig) {
 	}
 
 	var iceServers = pcConfig.iceServers,
-		i, len, iceServer;
+		i,
+		len,
+		iceServer;
 
 	if (!Array.isArray(iceServers)) {
 		pcConfig.iceServers = [];
@@ -726,11 +770,9 @@ function fixPcConfig(pcConfig) {
 	return pcConfig;
 }
 
-
 function isClosed() {
 	return this.signalingState === 'closed';
 }
-
 
 function onEvent(data) {
 	var type = data.type,
@@ -739,7 +781,7 @@ function onEvent(data) {
 		dataChannel,
 		id;
 
-	Object.defineProperty(event, 'target', {value: self, enumerable: true});
+	Object.defineProperty(event, 'target', { value: self, enumerable: true });
 
 	debug('onEvent() | [type:%s, data:%o]', type, data);
 
@@ -784,7 +826,7 @@ function onEvent(data) {
 			break;
 
 		case 'track':
-			var track = event.track = new MediaStreamTrack(data.track);
+			var track = (event.track = new MediaStreamTrack(data.track));
 			event.receiver = new RTCRtpReceiver({ track: track });
 			event.transceiver = new RTCRtpTransceiver({ receiver: event.receiver });
 			event.streams = [];
@@ -804,14 +846,17 @@ function onEvent(data) {
 			break;
 
 		case 'addstream':
-
 			// Append to the remote streams.
-			this.remoteStreams[data.streamId] = this.remoteStreams[data.streamId] || MediaStream.create(data.stream);
+			this.remoteStreams[data.streamId] =
+				this.remoteStreams[data.streamId] || MediaStream.create(data.stream);
 
 			event.stream = this.remoteStreams[data.streamId];
 
 			// Emit "connected" on the stream if ICE connected.
-			if (this.iceConnectionState === 'connected' || this.iceConnectionState === 'completed') {
+			if (
+				this.iceConnectionState === 'connected' ||
+				this.iceConnectionState === 'completed'
+			) {
 				event.stream.emitConnected();
 			}
 			break;

--- a/js/RTCRtpReceiver.js
+++ b/js/RTCRtpReceiver.js
@@ -3,7 +3,6 @@
  */
 module.exports = RTCRtpReceiver;
 
-
 function RTCRtpReceiver(data) {
 	data = data || {};
 

--- a/js/RTCRtpSender.js
+++ b/js/RTCRtpSender.js
@@ -33,12 +33,12 @@ RTCRtpSender.prototype.replaceTrack = function (withTrack) {
 		var event = new Event('negotiationneeded');
 		pc.dispatchEvent('negotiationneeded', event);
 
-		pc.addEventListener("signalingstatechange", function listener() {
-			if (pc.signalingState === "closed") {
-				pc.removeEventListener("signalingstatechange", listener);
+		pc.addEventListener('signalingstatechange', function listener() {
+			if (pc.signalingState === 'closed') {
+				pc.removeEventListener('signalingstatechange', listener);
 				reject();
-			} else if (pc.signalingState === "stable") {
-				pc.removeEventListener("signalingstatechange", listener);
+			} else if (pc.signalingState === 'stable') {
+				pc.removeEventListener('signalingstatechange', listener);
 				resolve();
 			}
 		});

--- a/js/RTCRtpTransceiver.js
+++ b/js/RTCRtpTransceiver.js
@@ -3,7 +3,6 @@
  */
 module.exports = RTCRtpTransceiver;
 
-
 function RTCRtpTransceiver(data) {
 	data = data || {};
 

--- a/js/RTCSessionDescription.js
+++ b/js/RTCSessionDescription.js
@@ -3,7 +3,6 @@
  */
 module.exports = RTCSessionDescription;
 
-
 function RTCSessionDescription(data) {
 	data = data || {};
 

--- a/js/enumerateDevices.js
+++ b/js/enumerateDevices.js
@@ -3,19 +3,15 @@
  */
 module.exports = enumerateDevices;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:enumerateDevices'),
+var debug = require('debug')('iosrtc:enumerateDevices'),
 	exec = require('cordova/exec'),
 	MediaDeviceInfo = require('./MediaDeviceInfo'),
 	Errors = require('./Errors');
 
-
 function enumerateDevices() {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
 	Errors.detectDeprecatedCallbaksUsage('cordova.plugins.iosrtc.enumerateDevices', arguments);
@@ -30,11 +26,9 @@ function enumerateDevices() {
 	});
 }
 
-
 /**
  * Private API.
  */
-
 
 function getMediaDeviceInfos(devices) {
 	debug('getMediaDeviceInfos() | [devices:%o]', devices);

--- a/js/getUserMedia.js
+++ b/js/getUserMedia.js
@@ -3,12 +3,10 @@
  */
 module.exports = getUserMedia;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:getUserMedia'),
+var debug = require('debug')('iosrtc:getUserMedia'),
 	debugerror = require('debug')('iosrtc:ERROR:getUserMedia'),
 	exec = require('cordova/exec'),
 	MediaStream = require('./MediaStream'),
@@ -22,26 +20,27 @@ function isPositiveFloat(number) {
 	return typeof number === 'number' && number >= 0;
 }
 
-
 function getUserMedia(constraints) {
-
 	// Detect callback usage to assist 5.0.1 to 5.0.2 migration
 	// TODO remove on 6.0.0
 	Errors.detectDeprecatedCallbaksUsage('cordova.plugins.iosrtc.getUserMedia', arguments);
 
 	debug('[original constraints:%o]', constraints);
 
-	var
-		audioRequested = false,
+	var audioRequested = false,
 		videoRequested = false,
 		newConstraints = {};
 
 	if (
 		typeof constraints !== 'object' ||
-			(!constraints.hasOwnProperty('audio') && !constraints.hasOwnProperty('video'))
+		(!constraints.hasOwnProperty('audio') && !constraints.hasOwnProperty('video'))
 	) {
 		return new Promise(function (resolve, reject) {
-			reject(new Errors.MediaStreamError('constraints must be an object with at least "audio" or "video" keys'));
+			reject(
+				new Errors.MediaStreamError(
+					'constraints must be an object with at least "audio" or "video" keys'
+				)
+			);
 		});
 	}
 
@@ -137,7 +136,6 @@ function getUserMedia(constraints) {
 
 	// Get video constraints
 	if (videoRequested) {
-
 		// Handle object video constraints
 		newConstraints.video = {};
 
@@ -146,13 +144,12 @@ function getUserMedia(constraints) {
 		// The mandatory / optional syntax was deprecated a in 2014, and minWidth and minHeight the year before that.
 		if (
 			typeof constraints.video === 'object' &&
-				(typeof constraints.video.optional === 'object' || typeof constraints.video.mandatory === 'object')
+			(typeof constraints.video.optional === 'object' ||
+				typeof constraints.video.mandatory === 'object')
 		) {
-
 			var videoConstraints = {};
 
 			if (Array.isArray(constraints.video.optional)) {
-
 				/*
 				Example of constraints.video.optional:
 					{
@@ -180,10 +177,12 @@ function getUserMedia(constraints) {
 				Object.values(constraints.video.optional).forEach(function (optional) {
 					var optionalConstraintName = Object.keys(optional)[0],
 						optionalConstraintValue = optional[optionalConstraintName];
-					videoConstraints[optionalConstraintName] = Array.isArray(optionalConstraintValue) ?
-																optionalConstraintValue[0] : optionalConstraintValue;
+					videoConstraints[optionalConstraintName] = Array.isArray(
+						optionalConstraintValue
+					)
+						? optionalConstraintValue[0]
+						: optionalConstraintValue;
 				});
-
 			} else if (typeof constraints.video.mandatory === 'object') {
 				videoConstraints = constraints.video.mandatory;
 			}
@@ -233,24 +232,24 @@ function getUserMedia(constraints) {
 			newConstraints.video.deviceId = {
 				exact: constraints.video.deviceId
 			};
-
-		// Also check video sourceId (mangled by adapter.js).
 		} else if (typeof constraints.video.sourceId === 'string') {
+			// Also check video sourceId (mangled by adapter.js).
 			newConstraints.video.deviceId = {
 				exact: constraints.video.sourceId
 			};
-
-		// Also check deviceId.(exact|ideal)
 		} else if (typeof constraints.video.deviceId === 'object') {
+			// Also check deviceId.(exact|ideal)
 			if (!!constraints.video.deviceId.exact) {
 				newConstraints.video.deviceId = {
-					exact: Array.isArray(constraints.video.deviceId.exact) ?
-						constraints.video.deviceId.exact[0] : constraints.video.deviceId.exact
+					exact: Array.isArray(constraints.video.deviceId.exact)
+						? constraints.video.deviceId.exact[0]
+						: constraints.video.deviceId.exact
 				};
 			} else if (!!constraints.video.deviceId.ideal) {
 				newConstraints.video.deviceId = {
-					ideal: Array.isArray(constraints.video.deviceId.ideal) ?
-							constraints.video.deviceId.ideal[0] : constraints.video.deviceId.ideal
+					ideal: Array.isArray(constraints.video.deviceId.ideal)
+						? constraints.video.deviceId.ideal[0]
+						: constraints.video.deviceId.ideal
 				};
 			}
 		}
@@ -270,9 +269,8 @@ function getUserMedia(constraints) {
 			if (isPositiveInteger(constraints.video.width.ideal)) {
 				newConstraints.video.width.ideal = constraints.video.width.ideal;
 			}
-
-		// Get requested width long as exact
 		} else if (isPositiveInteger(constraints.video.width)) {
+			// Get requested width long as exact
 			newConstraints.video.width = {
 				exact: constraints.video.width
 			};
@@ -293,9 +291,8 @@ function getUserMedia(constraints) {
 			if (isPositiveInteger(constraints.video.height.ideal)) {
 				newConstraints.video.height.ideal = constraints.video.height.ideal;
 			}
-
-		// Get requested height long as exact
 		} else if (isPositiveInteger(constraints.video.height)) {
+			// Get requested height long as exact
 			newConstraints.video.height = {
 				exact: constraints.video.height
 			};
@@ -305,10 +302,16 @@ function getUserMedia(constraints) {
 		if (typeof constraints.video.frameRate === 'object') {
 			newConstraints.video.frameRate = {};
 			if (isPositiveFloat(constraints.video.frameRate.min)) {
-				newConstraints.video.frameRate.min = parseFloat(constraints.video.frameRate.min, 10);
+				newConstraints.video.frameRate.min = parseFloat(
+					constraints.video.frameRate.min,
+					10
+				);
 			}
 			if (isPositiveFloat(constraints.video.frameRate.max)) {
-				newConstraints.video.frameRate.max = parseFloat(constraints.video.frameRate.max, 10);
+				newConstraints.video.frameRate.max = parseFloat(
+					constraints.video.frameRate.max,
+					10
+				);
 			}
 			if (isPositiveInteger(constraints.video.frameRate.exact)) {
 				newConstraints.video.frameRate.exact = constraints.video.frameRate.exact;
@@ -316,9 +319,8 @@ function getUserMedia(constraints) {
 			if (isPositiveInteger(constraints.video.frameRate.ideal)) {
 				newConstraints.video.frameRate.ideal = constraints.video.frameRate.ideal;
 			}
-
-		// Get requested frameRate double as exact
 		} else if (isPositiveFloat(constraints.video.frameRate)) {
+			// Get requested frameRate double as exact
 			newConstraints.video.frameRate = {
 				exact: parseFloat(constraints.video.frameRate, 10)
 			};
@@ -329,10 +331,16 @@ function getUserMedia(constraints) {
 		if (typeof constraints.video.aspectRatio === 'object') {
 			newConstraints.video.aspectRatio = {};
 			if (isPositiveFloat(constraints.video.aspectRatio.min)) {
-				newConstraints.video.aspectRatio.min = parseFloat(constraints.video.aspectRatio.min, 10);
+				newConstraints.video.aspectRatio.min = parseFloat(
+					constraints.video.aspectRatio.min,
+					10
+				);
 			}
 			if (isPositiveFloat(constraints.video.aspectRatio.max)) {
-				newConstraints.video.aspectRatio.max = parseFloat(constraints.video.aspectRatio.max, 10);
+				newConstraints.video.aspectRatio.max = parseFloat(
+					constraints.video.aspectRatio.max,
+					10
+				);
 			}
 			if (isPositiveInteger(constraints.video.aspectRatio.exact)) {
 				newConstraints.video.aspectRatio.exact = constraints.video.aspectRatio.exact;
@@ -367,7 +375,6 @@ function getUserMedia(constraints) {
 
 	// Get audio constraints
 	if (audioRequested) {
-
 		// Handle object audio constraints
 		newConstraints.audio = {};
 
@@ -376,19 +383,18 @@ function getUserMedia(constraints) {
 		// The mandatory / optional syntax was deprecated a in 2014, and minWidth and minHeight the year before that.
 		if (
 			typeof constraints.audio === 'object' &&
-				(typeof constraints.audio.optional === 'object' || typeof constraints.audio.mandatory === 'object')
+			(typeof constraints.audio.optional === 'object' ||
+				typeof constraints.audio.mandatory === 'object')
 		) {
-			if (
-				typeof constraints.audio.optional === 'object'
-			) {
+			if (typeof constraints.audio.optional === 'object') {
 				if (typeof constraints.audio.optional.sourceId === 'string') {
 					newConstraints.audio.deviceId = {
 						ideal: constraints.audio.optional.sourceId
 					};
 				} else if (
 					Array.isArray(constraints.audio.optional) &&
-						typeof constraints.audio.optional[0] === 'object' &&
-							typeof constraints.audio.optional[0].sourceId === 'string'
+					typeof constraints.audio.optional[0] === 'object' &&
+					typeof constraints.audio.optional[0].sourceId === 'string'
 				) {
 					newConstraints.audio.deviceId = {
 						ideal: constraints.audio.optional[0].sourceId
@@ -396,7 +402,7 @@ function getUserMedia(constraints) {
 				}
 			} else if (
 				constraints.audio.mandatory &&
-					typeof constraints.audio.mandatory.sourceId === 'string'
+				typeof constraints.audio.mandatory.sourceId === 'string'
 			) {
 				newConstraints.audio.deviceId = {
 					exact: constraints.audio.mandatory.sourceId
@@ -409,24 +415,24 @@ function getUserMedia(constraints) {
 			newConstraints.audio.deviceId = {
 				exact: constraints.audio.deviceId
 			};
-
-		// Also check audio sourceId (mangled by adapter.js).
 		} else if (typeof constraints.audio.sourceId === 'string') {
+			// Also check audio sourceId (mangled by adapter.js).
 			newConstraints.audio.deviceId = {
 				exact: constraints.audio.sourceId
 			};
-
-		// Also check deviceId.(exact|ideal)
 		} else if (typeof constraints.audio.deviceId === 'object') {
+			// Also check deviceId.(exact|ideal)
 			if (!!constraints.audio.deviceId.exact) {
 				newConstraints.audio.deviceId = {
-					exact: Array.isArray(constraints.audio.deviceId.exact) ?
-						constraints.audio.deviceId.exact[0] : constraints.audio.deviceId.exact
+					exact: Array.isArray(constraints.audio.deviceId.exact)
+						? constraints.audio.deviceId.exact[0]
+						: constraints.audio.deviceId.exact
 				};
 			} else if (!!constraints.audio.deviceId.ideal) {
 				newConstraints.audio.deviceId = {
-					ideal: Array.isArray(constraints.audio.deviceId.ideal) ?
-							constraints.audio.deviceId.ideal[0] : constraints.audio.deviceId.ideal
+					ideal: Array.isArray(constraints.audio.deviceId.ideal)
+						? constraints.audio.deviceId.ideal[0]
+						: constraints.audio.deviceId.ideal
 				};
 			}
 		}

--- a/js/iosrtc.js
+++ b/js/iosrtc.js
@@ -2,59 +2,53 @@
  * Variables.
  */
 
-var
-	// Dictionary of MediaStreamRenderers.
+var // Dictionary of MediaStreamRenderers.
 	// - key: MediaStreamRenderer id.
 	// - value: MediaStreamRenderer.
 	mediaStreamRenderers = {},
-
 	// Dictionary of MediaStreams.
 	// - key: MediaStream blobId.
 	// - value: MediaStream.
 	mediaStreams = {},
-
-
-/**
- * Dependencies.
- */
-	debug                  = require('debug')('iosrtc'),
-	exec                   = require('cordova/exec'),
-	domready               = require('domready'),
-
-	getUserMedia           = require('./getUserMedia'),
-	enumerateDevices       = require('./enumerateDevices'),
-	RTCPeerConnection      = require('./RTCPeerConnection'),
-	RTCSessionDescription  = require('./RTCSessionDescription'),
-	RTCIceCandidate        = require('./RTCIceCandidate'),
-	MediaDevices           = require('./MediaDevices'),
-	MediaStream            = require('./MediaStream'),
-	MediaStreamTrack       = require('./MediaStreamTrack'),
-	videoElementsHandler   = require('./videoElementsHandler');
-
+	/**
+	 * Dependencies.
+	 */
+	debug = require('debug')('iosrtc'),
+	exec = require('cordova/exec'),
+	domready = require('domready'),
+	getUserMedia = require('./getUserMedia'),
+	enumerateDevices = require('./enumerateDevices'),
+	RTCPeerConnection = require('./RTCPeerConnection'),
+	RTCSessionDescription = require('./RTCSessionDescription'),
+	RTCIceCandidate = require('./RTCIceCandidate'),
+	MediaDevices = require('./MediaDevices'),
+	MediaStream = require('./MediaStream'),
+	MediaStreamTrack = require('./MediaStreamTrack'),
+	videoElementsHandler = require('./videoElementsHandler');
 
 /**
  * Expose the iosrtc object.
  */
 module.exports = {
 	// Expose WebRTC classes and functions.
-	getUserMedia:          getUserMedia,
-	enumerateDevices:      enumerateDevices,
-	getMediaDevices:       enumerateDevices,  // TMP
-	RTCPeerConnection:     RTCPeerConnection,
+	getUserMedia: getUserMedia,
+	enumerateDevices: enumerateDevices,
+	getMediaDevices: enumerateDevices, // TMP
+	RTCPeerConnection: RTCPeerConnection,
 	RTCSessionDescription: RTCSessionDescription,
-	RTCIceCandidate:       RTCIceCandidate,
-	MediaDevices:          MediaDevices,
-	MediaStream:           MediaStream,
-	MediaStreamTrack:      MediaStreamTrack,
+	RTCIceCandidate: RTCIceCandidate,
+	MediaDevices: MediaDevices,
+	MediaStream: MediaStream,
+	MediaStreamTrack: MediaStreamTrack,
 
 	// Expose a function to refresh current videos rendering a MediaStream.
-	refreshVideos:         videoElementsHandler.refreshVideos,
+	refreshVideos: videoElementsHandler.refreshVideos,
 
 	// Expose a function to handle a video not yet inserted in the DOM.
-	observeVideo:          videoElementsHandler.observeVideo,
+	observeVideo: videoElementsHandler.observeVideo,
 
 	// Select audio output (earpiece or speaker).
-	selectAudioOutput:     selectAudioOutput,
+	selectAudioOutput: selectAudioOutput,
 
 	// turnOnSpeaker with options
 	turnOnSpeaker: turnOnSpeaker,
@@ -66,19 +60,18 @@ module.exports = {
 	initAudioDevices: initAudioDevices,
 
 	// Expose a function to pollute window and naigator namespaces.
-	registerGlobals:       registerGlobals,
+	registerGlobals: registerGlobals,
 
 	// Expose the debug module.
-	debug:                 require('debug'),
+	debug: require('debug'),
 
 	// Debug function to see what happens internally.
-	dump:                  dump,
+	dump: dump,
 
 	// Debug Stores to see what happens internally.
-	mediaStreamRenderers:  mediaStreamRenderers,
-	mediaStreams:          mediaStreams
+	mediaStreamRenderers: mediaStreamRenderers,
+	mediaStreams: mediaStreams
 };
-
 
 domready(function () {
 	// Let the MediaStream class and the videoElementsHandler share same MediaStreams container.
@@ -110,7 +103,7 @@ function selectAudioOutput(output) {
 function turnOnSpeaker(isTurnOn) {
 	debug('turnOnSpeaker() | [isTurnOn:"%s"]', isTurnOn);
 
-	exec(null, null, 'iosrtcPlugin', "RTCTurnOnSpeaker", [isTurnOn]);
+	exec(null, null, 'iosrtcPlugin', 'RTCTurnOnSpeaker', [isTurnOn]);
 }
 
 function requestPermission(needMic, needCamera, callback) {
@@ -123,19 +116,20 @@ function requestPermission(needMic, needCamera, callback) {
 	function error() {
 		callback(false);
 	}
-	exec(ok, error, 'iosrtcPlugin', "RTCRequestPermission", [needMic, needCamera]);
+	exec(ok, error, 'iosrtcPlugin', 'RTCRequestPermission', [needMic, needCamera]);
 }
 
 function initAudioDevices() {
 	debug('initAudioDevices()');
 
-	exec(null, null, 'iosrtcPlugin', "initAudioDevices", []);
+	exec(null, null, 'iosrtcPlugin', 'initAudioDevices', []);
 }
 
 function callbackifyMethod(originalMethod) {
-	return function (arg) { // jshint ignore:line
-		var success, failure,
-		  originalArgs = Array.prototype.slice.call(arguments);
+	return function () {
+		var success,
+			failure,
+			originalArgs = Array.prototype.slice.call(arguments);
 
 		var callbackArgs = [];
 		originalArgs.forEach(function (arg) {
@@ -199,18 +193,18 @@ function registerGlobals(doNotRestoreCallbacksSupport) {
 		restoreCallbacksSupport();
 	}
 
-	navigator.getUserMedia                  = getUserMedia;
-	navigator.webkitGetUserMedia            = getUserMedia;
-	navigator.mediaDevices.getUserMedia     = getUserMedia;
+	navigator.getUserMedia = getUserMedia;
+	navigator.webkitGetUserMedia = getUserMedia;
+	navigator.mediaDevices.getUserMedia = getUserMedia;
 	navigator.mediaDevices.enumerateDevices = enumerateDevices;
 
-	window.RTCPeerConnection                = RTCPeerConnection;
-	window.webkitRTCPeerConnection          = RTCPeerConnection;
-	window.RTCSessionDescription            = RTCSessionDescription;
-	window.RTCIceCandidate                  = RTCIceCandidate;
-	window.MediaStream                      = MediaStream;
-	window.webkitMediaStream                = MediaStream;
-	window.MediaStreamTrack                 = MediaStreamTrack;
+	window.RTCPeerConnection = RTCPeerConnection;
+	window.webkitRTCPeerConnection = RTCPeerConnection;
+	window.RTCSessionDescription = RTCSessionDescription;
+	window.RTCIceCandidate = RTCIceCandidate;
+	window.MediaStream = MediaStream;
+	window.webkitMediaStream = MediaStream;
+	window.MediaStreamTrack = MediaStreamTrack;
 
 	// Apply CanvasRenderingContext2D.drawImage monkey patch
 	var drawImage = CanvasRenderingContext2D.prototype.drawImage;
@@ -219,13 +213,13 @@ function registerGlobals(doNotRestoreCallbacksSupport) {
 		var context = this;
 		if (arg instanceof HTMLVideoElement && arg.render) {
 			arg.render.save(function (data) {
-			    var img = new window.Image();
-			    img.addEventListener("load", function () {
-			    	args.splice(0, 1, img);
-			        drawImage.apply(context, args);
-			    });
-			    img.setAttribute("src", "data:image/jpg;base64," + data);
-		  	});
+				var img = new window.Image();
+				img.addEventListener('load', function () {
+					args.splice(0, 1, img);
+					drawImage.apply(context, args);
+				});
+				img.setAttribute('src', 'data:image/jpg;base64,' + data);
+			});
 		} else {
 			return drawImage.apply(context, args);
 		}

--- a/js/videoElementsHandler.js
+++ b/js/videoElementsHandler.js
@@ -6,32 +6,25 @@ module.exports = videoElementsHandler;
 module.exports.observeVideo = observeVideo;
 module.exports.refreshVideos = refreshVideos;
 
-
 /**
  * Dependencies.
  */
-var
-	debug = require('debug')('iosrtc:videoElementsHandler'),
+var debug = require('debug')('iosrtc:videoElementsHandler'),
 	MediaStreamRenderer = require('./MediaStreamRenderer'),
-
-
-/**
- * Local variables.
- */
+	/**
+	 * Local variables.
+	 */
 
 	// RegExp for Blob URI.
 	BLOB_INTERNAL_URI_REGEX = new RegExp(/^blob:/),
-
 	// Dictionary of MediaStreamRenderers (provided via module argument).
 	// - key: MediaStreamRenderer id.
 	// - value: MediaStreamRenderer.
 	mediaStreamRenderers,
-
 	// Dictionary of MediaStreams (provided via module argument).
 	// - key: MediaStream blobId.
 	// - value: MediaStream.
 	mediaStreams,
-
 	// Video element mutation observer.
 	videoObserver = new MutationObserver(function (mutations) {
 		var i, numMutations, mutation, video;
@@ -52,12 +45,9 @@ var
 			handleVideo(video);
 		}
 	}),
-
 	// DOM mutation observer.
 	domObserver = new MutationObserver(function (mutations) {
-		var
-			i, numMutations, mutation,
-			j, numNodes, node;
+		var i, numMutations, mutation, j, numNodes, node;
 
 		for (i = 0, numMutations = mutations.length; i < numMutations; i++) {
 			mutation = mutations[i];
@@ -137,9 +127,10 @@ function refreshVideos() {
 }
 
 function videoElementsHandler(_mediaStreams, _mediaStreamRenderers) {
-	var
-		existingVideos = document.querySelectorAll('video'),
-		i, len, video;
+	var existingVideos = document.querySelectorAll('video'),
+		i,
+		len,
+		video;
 
 	mediaStreams = _mediaStreams;
 	mediaStreamRenderers = _mediaStreamRenderers;
@@ -174,7 +165,6 @@ function videoElementsHandler(_mediaStreams, _mediaStreamRenderers) {
 		// attributeFilter:
 	});
 }
-
 
 function observeVideo(video) {
 	debug('observeVideo()');
@@ -214,7 +204,6 @@ function observeVideo(video) {
 	// video.srcObject = null will trigger onemptied events.
 
 	video.addEventListener('loadstart', function () {
-
 		var hasStream = video.srcObject || video.src;
 
 		if (hasStream && !video._iosrtcMediaStreamRendererId) {
@@ -242,7 +231,10 @@ function observeVideo(video) {
 
 	// Intercept video 'error' events if it's due to the attached MediaStream.
 	video.addEventListener('error', function (event) {
-		if (video.error.code === window.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED && BLOB_INTERNAL_URI_REGEX.test(video.src)) {
+		if (
+			video.error.code === window.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED &&
+			BLOB_INTERNAL_URI_REGEX.test(video.src)
+		) {
 			debug('stopping "error" event propagation for video element');
 
 			event.stopImmediatePropagation();
@@ -250,20 +242,17 @@ function observeVideo(video) {
 	});
 }
 
-
 /**
  * Private API.
  */
 
 function handleVideo(video) {
-	var
-		stream;
+	var stream;
 
 	// The app has set video.srcObject.
 	if (video.srcObject) {
 		stream = video.srcObject;
 		if (stream && typeof stream.getBlobId === 'function') {
-
 			if (!stream.getBlobId()) {
 				// If this video element was previously handling a MediaStreamRenderer, release it.
 				releaseMediaStreamRenderer(video);
@@ -274,7 +263,6 @@ function handleVideo(video) {
 			provideMediaStreamRenderer(video, stream.getBlobId());
 		}
 	} else if (video.src) {
-
 		var xhr = new XMLHttpRequest();
 		xhr.open('GET', video.src, true);
 		xhr.responseType = 'blob';
@@ -315,10 +303,8 @@ function handleVideo(video) {
 	}
 }
 
-
 function provideMediaStreamRenderer(video, mediaStreamBlobId) {
-	var
-		mediaStream = mediaStreams[mediaStreamBlobId],
+	var mediaStream = mediaStreams[mediaStreamBlobId],
 		mediaStreamRenderer = mediaStreamRenderers[video._iosrtcMediaStreamRendererId];
 
 	if (!mediaStream) {
@@ -364,7 +350,11 @@ function provideMediaStreamRenderer(video, mediaStreamBlobId) {
 		readyState: {
 			configurable: true,
 			get: function () {
-				if (mediaStreamRenderer && mediaStreamRenderer.stream && mediaStreamRenderer.stream.connected) {
+				if (
+					mediaStreamRenderer &&
+					mediaStreamRenderer.stream &&
+					mediaStreamRenderer.stream.connected
+				) {
 					return video.HAVE_ENOUGH_DATA;
 				} else {
 					return video.HAVE_NOTHING;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,61 @@
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
       }
     },
     "@types/color-name": {
@@ -76,9 +131,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -103,23 +158,6 @@
       "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.11.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
-        }
       }
     },
     "ansi-gray": {
@@ -862,47 +900,31 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
     },
     "chokidar": {
       "version": "2.1.8",
@@ -966,21 +988,6 @@
         "exit": "0.1.2",
         "glob": "^7.1.1"
       }
-    },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true
     },
     "cliui": {
       "version": "3.2.0",
@@ -1236,16 +1243,25 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "crypto-browserify": {
@@ -1741,6 +1757,23 @@
         "once": "^1.4.0"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        }
+      }
+    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -1889,22 +1922,24 @@
       }
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
+      "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
@@ -1913,30 +1948,28 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "glob-parent": {
@@ -1949,20 +1982,38 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
@@ -1976,29 +2027,45 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.1",
+        "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -2188,17 +2255,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -2282,6 +2338,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2299,15 +2361,6 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
-    },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      }
     },
     "file-entry-cache": {
       "version": "5.0.1",
@@ -2489,6 +2542,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-value": {
@@ -2676,17 +2735,6 @@
         "derequire": "^2.0.0",
         "plugin-error": "^1.0.0",
         "through2": "^2.0.0"
-      }
-    },
-    "gulp-eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-6.0.0.tgz",
-      "integrity": "sha512-dCVPSh1sA+UVhn7JSQt7KEb4An2sQNbOdB3PA8UCfxsoPlAKjJHxYHGXdXC7eb+V1FAnilSFFqslPrq037l1ig==",
-      "dev": true,
-      "requires": {
-        "eslint": "^6.0.0",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1"
       }
     },
     "gulp-header": {
@@ -2962,15 +3010,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -3034,86 +3073,6 @@
       "dev": true,
       "requires": {
         "source-map": "~0.5.3"
-      }
-    },
-    "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "insert-module-globals": {
@@ -3594,13 +3553,13 @@
       }
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "liftoff": {
@@ -3853,12 +3812,6 @@
         }
       }
     },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -3950,12 +3903,6 @@
       "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
@@ -3992,12 +3939,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -4153,27 +4094,18 @@
         "wrappy": "1"
       }
     },
-    "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
     "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       },
       "dependencies": {
         "fast-levenshtein": {
@@ -4207,12 +4139,6 @@
       "requires": {
         "lcid": "^1.0.0"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -4341,9 +4267,9 @@
       "dev": true
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -4456,10 +4382,25 @@
       "dev": true
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-hrtime": {
       "version": "1.0.3",
@@ -4684,9 +4625,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
     "remove-bom-buffer": {
@@ -4797,16 +4738,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -4830,21 +4761,6 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
-    },
-    "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -4942,18 +4858,18 @@
       }
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "shell-quote": {
@@ -4966,12 +4882,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "simple-concat": {
@@ -5579,15 +5489,6 @@
         "process": "~0.11.0"
       }
     },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
-    },
     "to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -5655,12 +5556,6 @@
         "through2": "^2.0.3"
       }
     },
-    "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
-    },
     "tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
@@ -5674,12 +5569,12 @@
       "dev": true
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "^1.2.1"
       }
     },
     "type-fest": {
@@ -5887,9 +5782,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "v8flags": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues"
   },
   "scripts": {
-    "lint": "gulp lint",
+    "lint": "gulp lint && eslint '**/*.js'",
+    "lint-fix": "eslint --fix '**/*.js'",
     "build": "gulp browserify"
   },
   "dependencies": {
@@ -40,13 +41,16 @@
   },
   "devDependencies": {
     "browserify": "^14.4.0",
+    "eslint": "7.12.1",
+    "eslint-config-prettier": "6.15.0",
+    "eslint-plugin-prettier": "3.1.4",
     "gulp": "^4.0.2",
     "gulp-derequire": "^2.1.1",
-    "gulp-eslint": "^6.0.0",
     "gulp-header": "^2.0.9",
     "gulp-jshint": "^2.0.4",
     "jshint": "^2.9.4",
     "jshint-stylish": "~2.2.1",
+    "prettier": "2.1.2",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },


### PR DESCRIPTION
This adds [prettier](https://prettier.io/) to the eslint config.  Running `npm run lint-fix` will automatically run prettier on all js files (except the bundled output).  Also fixed the lint gulp task, which would run eslint but not fail if eslint had errors.  I tried to keep the prettier config as in-line with your previous code styles as I can.  Main benefit to this change is it makes it really easy for contributors to follow code style guidelines without having to think about the code style as they go.  Most editors have built-in prettier support, so saving a file will automatically reformat the JS to match project styles.