### PR TITLE
fix PluginMediaStreamRenderer#save() memory leak using autoreleasepool

### DIFF
--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -240,14 +240,16 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 	}
 	
 	func save() -> String {
-        NSLog("PluginMediaStreamRenderer#save()")
-        UIGraphicsBeginImageContextWithOptions(videoView.bounds.size, videoView.isOpaque, 0.0)
-        videoView.drawHierarchy(in: videoView.bounds, afterScreenUpdates: false)
-		let snapshotImageFromMyView = UIGraphicsGetImageFromCurrentImageContext()
-		UIGraphicsEndImageContext()
-		let imageData = snapshotImageFromMyView?.jpegData(compressionQuality: 1.0)
-		let strBase64 = imageData?.base64EncodedString(options: .lineLength64Characters)
-		return strBase64!;
+		return autoreleasepool { () -> String in
+			NSLog("PluginMediaStreamRenderer#save()")
+			UIGraphicsBeginImageContextWithOptions(videoView.bounds.size, videoView.isOpaque, 0.0)
+			videoView.drawHierarchy(in: videoView.bounds, afterScreenUpdates: false)
+			let snapshotImageFromMyView = UIGraphicsGetImageFromCurrentImageContext()
+			UIGraphicsEndImageContext()
+			let imageData = snapshotImageFromMyView?.jpegData(compressionQuality: 1.0)
+			let strBase64 = imageData?.base64EncodedString(options: .lineLength64Characters)
+			return strBase64!;
+		}
 	}
 	
 	func stop() {


### PR DESCRIPTION
# Testing

To test `bugs/PluginMediaStreamRendererSaveMemoryLeak` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/PluginMediaStreamRendererSaveMemoryLeak --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```