### PR TITLE
fix: PluginMediaStreamTrack.eventListener  possible Fatal error: Unex…

### DIFF
--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -120,11 +120,17 @@ class PluginMediaStreamTrack : NSObject {
 		// Let's try setEnabled(false), but it also fails.
 		self.rtcMediaStreamTrack.isEnabled = false
 		
-		self.eventListener!([
-			"type": "statechange",
-			"readyState": "ended",
-			"enabled": self.rtcMediaStreamTrack.isEnabled ? true : false
-		])
+		if (self.eventListener != nil) {
+			self.eventListener?([
+				"type": "statechange",
+				"readyState": "ended",
+				"enabled": self.rtcMediaStreamTrack.isEnabled ? true : false
+			])
+		}
+		
+		if (self.eventListenerForEnded != nil) {
+			self.eventListenerForEnded!()
+		}
 
 		for (_, render) in self.renders {
 			render.stop()

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -127,10 +127,6 @@ class PluginMediaStreamTrack : NSObject {
 				"enabled": self.rtcMediaStreamTrack.isEnabled ? true : false
 			])
 		}
-		
-		if (self.eventListenerForEnded != nil) {
-			self.eventListenerForEnded!()
-		}
 
 		for (_, render) in self.renders {
 			render.stop()


### PR DESCRIPTION
…pectedly found nil while unwrapping an Optional value: file XXXXXXX/PluginMediaStreamTrack.swift, line 123 (lldb) bug

Fix https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues/601

# Testing

To test `bugs/PluginMediaStreamTrack.eventListener` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/PluginMediaStreamTrack.eventListener --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```