### PR TITLE
restore fix to handle possible duplicate remote trackId/mediaId

### DIFF
--- a/src/PluginMediaStream.swift
+++ b/src/PluginMediaStream.swift
@@ -21,7 +21,11 @@ class PluginMediaStream : NSObject {
 		if (streamId == nil) {
 			// Handle possible duplicate remote trackId with  janus or short duplicate name
 			// See: https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues/432
-			self.id = rtcMediaStream.streamId + "_" + UUID().uuidString;
+			if (rtcMediaStream.streamId.count < 36) {
+				self.id = rtcMediaStream.streamId + "_" + UUID().uuidString;
+			} else {
+				self.id = rtcMediaStream.streamId;
+			}
 		} else {
 			self.id = streamId!;
 		}

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -18,7 +18,11 @@ class PluginMediaStreamTrack : NSObject {
 		if (trackId == nil) {
 			// Handle possible duplicate remote trackId with  janus or short duplicate name
 			// See: https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues/432
-			self.id = rtcMediaStreamTrack.trackId + "_" + UUID().uuidString;
+			if (rtcMediaStreamTrack.trackId.count<36) {
+				self.id = rtcMediaStreamTrack.trackId + "_" + UUID().uuidString;
+			} else {
+				self.id = rtcMediaStreamTrack.trackId;
+			}
 		} else {
 			self.id = trackId!;
 		}


### PR DESCRIPTION
Fix #592

# Testing

To test `bugs/MediaStreamUUID` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/MediaStreamUUID --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```