### PR TITLE
Fix MediaStreamTrack lifecycle and make GetStats logs silent.

### DIFF
--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -440,14 +440,22 @@ function onEvent(data) {
 
 	switch (type) {
 		case 'addtrack':
-			track = new MediaStreamTrack(data.track);
-
-			if (track.kind === 'audio') {
-				this._audioTracks[track.id] = track;
-			} else if (track.kind === 'video') {
-				this._videoTracks[track.id] = track;
+			// check if a track already exists before initializing a new 
+			// track and calling setListener again.
+			if(data.track.kind === 'audio'){
+				track = this._audioTracks[data.track.id];
+			 }else if(data.track.kind === 'video'){
+			   track = this._videoTracks[data.track.id]
 			}
-			addListenerForTrackEnded.call(this, track);
+		   if(!track){
+			   track = new MediaStreamTrack(data.track);
+			   if (track.kind === 'audio') {
+				   this._audioTracks[track.id] = track;
+			   } else if (track.kind === 'video') {
+				   this._videoTracks[track.id] = track;
+			   }
+			   addListenerForTrackEnded.call(this, track);
+		   }
 
 			event = new Event('addtrack');
 			event.track = track;

--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -440,22 +440,22 @@ function onEvent(data) {
 
 	switch (type) {
 		case 'addtrack':
-			// check if a track already exists before initializing a new 
+			// check if a track already exists before initializing a new
 			// track and calling setListener again.
-			if(data.track.kind === 'audio'){
+			if (data.track.kind === 'audio') {
 				track = this._audioTracks[data.track.id];
-			 }else if(data.track.kind === 'video'){
-			   track = this._videoTracks[data.track.id]
+			} else if (data.track.kind === 'video') {
+				track = this._videoTracks[data.track.id];
 			}
-		   if(!track){
-			   track = new MediaStreamTrack(data.track);
-			   if (track.kind === 'audio') {
-				   this._audioTracks[track.id] = track;
-			   } else if (track.kind === 'video') {
-				   this._videoTracks[track.id] = track;
-			   }
-			   addListenerForTrackEnded.call(this, track);
-		   }
+			if (!track) {
+				track = new MediaStreamTrack(data.track);
+				if (track.kind === 'audio') {
+					this._audioTracks[track.id] = track;
+				} else if (track.kind === 'video') {
+					this._videoTracks[track.id] = track;
+				}
+				addListenerForTrackEnded.call(this, track);
+			}
 
 			event = new Event('addtrack');
 			event.track = track;

--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -622,9 +622,9 @@ RTCPeerConnection.prototype.addStream = function (stream) {
 	});
 	// Fixes after stopping all tracks and trying to connect again
 	// getting pluginMediaStream not found
-	stream.addEventListener("inactive", function(){
+	stream.addEventListener('inactive', function () {
 		delete self.localStreams[stream.id];
-	})
+	});
 
 	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addStream', [this.pcId, stream.id]);
 };

--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -620,6 +620,11 @@ RTCPeerConnection.prototype.addStream = function (stream) {
 			delete self.localTracks[track.id];
 		});
 	});
+	// Fixes after stopping all tracks and trying to connect again
+	// getting pluginMediaStream not found
+	stream.addEventListener("inactive", function(){
+		delete self.localStreams[stream.id];
+	})
 
 	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addStream', [this.pcId, stream.id]);
 };
@@ -688,7 +693,7 @@ RTCPeerConnection.prototype.getStats = function (selector) {
 		throw new Errors.InvalidStateError('peerconnection is closed');
 	}
 
-	debug('getStats() [selector:%o]', selector);
+	// debug('getStats() [selector:%o]', selector);
 
 	return new Promise(function (resolve, reject) {
 		function onResultOK(array) {

--- a/js/RTCStatsResponse.js
+++ b/js/RTCStatsResponse.js
@@ -17,7 +17,8 @@ function RTCStatsResponse(data) {
 	this.namedItem = function () {
 		return null;
 	};
-	this.values = function(){
+
+	this.values = function () {
 		return data;
-  	}
+	};
 }

--- a/js/RTCStatsResponse.js
+++ b/js/RTCStatsResponse.js
@@ -17,4 +17,7 @@ function RTCStatsResponse(data) {
 	this.namedItem = function () {
 		return null;
 	};
+	this.values = function(){
+		return data;
+  	}
 }

--- a/src/PluginMediaStream.swift
+++ b/src/PluginMediaStream.swift
@@ -21,7 +21,11 @@ class PluginMediaStream : NSObject {
 		if (streamId == nil) {
 			// Handle possible duplicate remote trackId with  janus or short duplicate name
 			// See: https://github.com/cordova-rtc/cordova-plugin-iosrtc/issues/432
-			self.id = rtcMediaStream.streamId + "_" + UUID().uuidString;
+			if (rtcMediaStream.streamId.count < 36) {
+				self.id = rtcMediaStream.streamId + "_" + UUID().uuidString;
+			} else {
+				self.id = rtcMediaStream.streamId;
+			}
 		} else {
 			self.id = streamId!;
 		}

--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -182,7 +182,8 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		}
 
 		self.onSetDescriptionFailureCallback = { (error: Error) -> Void in
-			NSLog("PluginRTCPeerConnection#setLocalDescription() | failure callback: %@", String(describing: error))
+			NSLog("PluginRTCPeerConnection#setLocalDescription() | failure callback: %@ description %@", 
+						String(describing: error), desc)
 
 			errback(error)
 		}
@@ -347,7 +348,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 	}
 
 	func addTrack(_ pluginMediaTrack: PluginMediaStreamTrack, _ streamIds: [String]) -> Bool {
-		NSLog("PluginRTCPeerConnection#addTrack()")
+		NSLog("PluginRTCPeerConnection#addTrack() trackId=%@ rtcId=%@")
 
 		if self.rtcPeerConnection.signalingState == RTCSignalingState.closed {
 			return false
@@ -355,6 +356,8 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 
 		let rtcMediaStreamTrack = pluginMediaTrack.rtcMediaStreamTrack;
 		var rtcSender = trackIdsToSenders[rtcMediaStreamTrack.trackId];
+		NSLog("PluginRTCPeerConnection#addTrack() trackId=%@ rtcId=%@ streamIds %@" , 
+				pluginMediaTrack.id, rtcMediaStreamTrack.trackId, streamIds);
 		if (rtcSender == nil) {
 			rtcSender = self.rtcPeerConnection.add(rtcMediaStreamTrack, streamIds: streamIds)
 			trackIdsToSenders[rtcMediaStreamTrack.trackId] = rtcSender;
@@ -458,7 +461,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		callback: @escaping (_ data: [[String:Any]]) -> Void,
 		errback: (_ error: NSError) -> Void
 	) {
-		NSLog("PluginRTCPeerConnection#getStats()")
+//		NSLog("PluginRTCPeerConnection#getStats()")
 
 		if self.rtcPeerConnection.signalingState == RTCSignalingState.closed {
 			return
@@ -475,7 +478,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 					"values" : report.values
 				])
 			}
-			NSLog("Stats:\n %@", data)
+//			NSLog("Stats:\n %@", data)
 			callback(data)
 		})
 	}


### PR DESCRIPTION
The pull request fixes issue #592 the local and remote tracks not visible. The issue was Twilio parses the a=ssrc to get the exact trackIds mapped to the msid. this can seen here https://github.com/twilio/twilio-webrtc.js/blob/87f7e61106f58e29364999d8753c773e5602536f/lib/util/sdp.js#L127-L129 . 

There was also a problem after releasing the stream in which the stream id was not being removed from the RTCPeerConnection localtracks leading to the next time someone is trying to publish a track it would fail.
