### PR TITLE
removed calling checkActive for connected local streams

### DIFF
--- a/js/MediaStream.js
+++ b/js/MediaStream.js
@@ -434,7 +434,7 @@ function checkActive() {
 	release();
 
 	function release() {
-		debug('all tracks are ended, releasing MediaStream %s' , self.id);
+		debug('all tracks are ended, releasing MediaStream %s', self.id);
 		self._active = false;
 		self.dispatchEvent(new Event('inactive'));
 

--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -500,15 +500,7 @@ RTCPeerConnection.prototype.addTrack = function (track, stream) {
 
 	// Fix webrtc-adapter bad SHIM on addStream
 	if (stream) {
-		if (!(stream instanceof MediaStream.originalMediaStream)) {
-			throw new Error('addTrack() must be called with a MediaStream instance as argument');
-		}
-
-		if (!this.localStreams[stream.id]) {
-			this.localStreams[stream.id] = stream;
-		}
-
-		exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addStream', [this.pcId, stream.id]);
+		this.addStream(stream);
 	}
 
 	for (id in this.localStreams) {
@@ -614,16 +606,13 @@ RTCPeerConnection.prototype.addStream = function (stream) {
 
 	this.localStreams[stream.id] = stream;
 
+	stream.addedToConnection = true;
+
 	stream.getTracks().forEach(function (track) {
 		self.localTracks[track.id] = track;
 		track.addEventListener('ended', function () {
 			delete self.localTracks[track.id];
 		});
-	});
-	// Fixes after stopping all tracks and trying to connect again
-	// getting pluginMediaStream not found
-	stream.addEventListener('inactive', function () {
-		delete self.localStreams[stream.id];
 	});
 
 	exec(null, null, 'iosrtcPlugin', 'RTCPeerConnection_addStream', [this.pcId, stream.id]);

--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -348,8 +348,6 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 	}
 
 	func addTrack(_ pluginMediaTrack: PluginMediaStreamTrack, _ streamIds: [String]) -> Bool {
-		NSLog("PluginRTCPeerConnection#addTrack() trackId=%@ rtcId=%@")
-
 		if self.rtcPeerConnection.signalingState == RTCSignalingState.closed {
 			return false
 		}


### PR DESCRIPTION
fixes #606  connected streams should not be recycled as a reference is kept inside some webrtc libraries. The library will use the same MediaStream to publish another track if the user decides to do so causing an error of pluginMediaStream does not exist on the Swift side