### PR TITLE
MediaStreamTrack: added getCapabilities().deviceId support for cam device media streams

### DIFF
--- a/js/MediaStreamTrack.js
+++ b/js/MediaStreamTrack.js
@@ -41,6 +41,7 @@ function MediaStreamTrack(dataFromEvent) {
 	this.kind = dataFromEvent.kind;
 	this.label = dataFromEvent.label;
 	this.muted = false; // TODO: No "muted" property in ObjC API.
+	this.capabilities = dataFromEvent.capabilities;
 	this.readyState = dataFromEvent.readyState;
 
 	// Private attributes.
@@ -96,9 +97,7 @@ MediaStreamTrack.prototype.clone = function () {
 };
 
 MediaStreamTrack.prototype.getCapabilities = function () {
-	//throw new Error('Not implemented.');
-	// SHAM
-	return new MediaTrackCapabilities();
+	return new MediaTrackCapabilities(this.capabilities);
 };
 
 MediaStreamTrack.prototype.getSettings = function () {

--- a/js/MediaTrackCapabilities.js
+++ b/js/MediaTrackCapabilities.js
@@ -6,4 +6,6 @@ module.exports = MediaTrackCapabilities;
 // Ref https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackcapabilities
 function MediaTrackCapabilities(data) {
 	data = data || {};
+
+	this.deviceId = data.deviceId;
 }

--- a/src/PluginGetUserMedia.swift
+++ b/src/PluginGetUserMedia.swift
@@ -123,6 +123,10 @@ class PluginGetUserMedia {
 				return
 			}
 
+			if let device = rtcVideoTrack!.videoCaptureController?.device {
+				rtcVideoTrack!.capabilities["deviceId"] = device.uniqueID
+			}
+
 			rtcMediaStream.addVideoTrack(rtcVideoTrack!)
 		}
 

--- a/src/PluginMediaStreamTrack.swift
+++ b/src/PluginMediaStreamTrack.swift
@@ -57,6 +57,7 @@ class PluginMediaStreamTrack : NSObject {
 			"kind": self.kind,
 			"trackId": self.rtcMediaStreamTrack.trackId,
 			"enabled": self.rtcMediaStreamTrack.isEnabled ? true : false,
+			"capabilities": self.rtcMediaStreamTrack.capabilities,
 			"readyState": self.getReadyState()
 		]
 	}

--- a/src/PluginRTCVideoCaptureController.swift
+++ b/src/PluginRTCVideoCaptureController.swift
@@ -24,6 +24,7 @@ extension RTCMediaStreamTrack {
 
 	class PropClass {
 		var videoCaptureController: PluginRTCVideoCaptureController?
+		let capabilities = NSMutableDictionary()
 	}
 
 	var _propClass : PropClass {
@@ -39,6 +40,12 @@ extension RTCMediaStreamTrack {
 		}
 		set {
 			_propClass.videoCaptureController = newValue
+		}
+	}
+
+	var capabilities: NSMutableDictionary {
+		get {
+			return _propClass.capabilities
 		}
 	}
 }

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -1168,6 +1168,7 @@ function MediaStreamTrack(dataFromEvent) {
 	this.kind = dataFromEvent.kind;
 	this.label = dataFromEvent.label;
 	this.muted = false; // TODO: No "muted" property in ObjC API.
+	this.capabilities = dataFromEvent.capabilities;
 	this.readyState = dataFromEvent.readyState;
 
 	// Private attributes.
@@ -1223,9 +1224,7 @@ MediaStreamTrack.prototype.clone = function () {
 };
 
 MediaStreamTrack.prototype.getCapabilities = function () {
-	//throw new Error('Not implemented.');
-	// SHAM
-	return new MediaTrackCapabilities();
+	return new MediaTrackCapabilities(this.capabilities);
 };
 
 MediaStreamTrack.prototype.getSettings = function () {
@@ -1295,6 +1294,8 @@ module.exports = MediaTrackCapabilities;
 // Ref https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackcapabilities
 function MediaTrackCapabilities(data) {
 	data = data || {};
+
+	this.deviceId = data.deviceId;
 }
 
 },{}],9:[function(_dereq_,module,exports){


### PR DESCRIPTION
I hope I didn't miss/break something... Thanks in advance.