### PR TITLE
Fix Malformed event dispatch on negotiationneeded #614

### DIFF
--- a/js/RTCRtpSender.js
+++ b/js/RTCRtpSender.js
@@ -31,7 +31,7 @@ RTCRtpSender.prototype.replaceTrack = function (withTrack) {
 
 		// https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event
 		var event = new Event('negotiationneeded');
-		pc.dispatchEvent('negotiationneeded', event);
+		pc.dispatchEvent(event);
 
 		pc.addEventListener('signalingstatechange', function listener() {
 			if (pc.signalingState === 'closed') {

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -2813,7 +2813,7 @@ RTCRtpSender.prototype.replaceTrack = function (withTrack) {
 
 		// https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event
 		var event = new Event('negotiationneeded');
-		pc.dispatchEvent('negotiationneeded', event);
+		pc.dispatchEvent(event);
 
 		pc.addEventListener('signalingstatechange', function listener() {
 			if (pc.signalingState === 'closed') {


### PR DESCRIPTION
update pc.dispatchEvent call to only pass the event, not a string and an event.