### PR TITLE
Check if pluginMediaStream had already the new track, otherwise add new track on PluginRTCPeerConnection ontrack

### DIFF
--- a/src/PluginMediaStream.swift
+++ b/src/PluginMediaStream.swift
@@ -99,6 +99,16 @@ class PluginMediaStream : NSObject {
 		self.eventListenerForRemoveTrack = eventListenerForRemoveTrack
 	}
 
+	func hasTrack(_ pluginMediaStreamTrack: PluginMediaStreamTrack) -> Bool {
+		if pluginMediaStreamTrack.kind == "audio" {
+			return self.audioTracks[pluginMediaStreamTrack.id] != nil;
+		} else if pluginMediaStreamTrack.kind == "video" {
+			return self.videoTracks[pluginMediaStreamTrack.id] != nil;
+		} else {
+			return false
+		}
+	}
+
 	func addTrack(_ pluginMediaStreamTrack: PluginMediaStreamTrack) -> Bool {
 		NSLog("PluginMediaStream#addTrack()")
 

--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -686,7 +686,7 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 	/** New track as been added. */
 	func peerConnection(_ peerConnection: RTCPeerConnection, didAdd rtpReceiver: RTCRtpReceiver, streams:[RTCMediaStream]) {
 
-		NSLog("PluginRTCPeerConnection | onaddtrack")
+		NSLog("PluginRTCPeerConnection | ontrack")
 
 		let pluginMediaTrack = getPluginMediaStreamTrack(rtpReceiver);
 
@@ -700,6 +700,11 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 			])
 		} else {
 			let pluginMediaStream = getPluginMediaStream(streams[0]);
+
+			// Check if pluginMediaStream had already the new track, otherwise add new track
+			if (pluginMediaStream!.hasTrack(pluginMediaTrack!) == false) {
+				pluginMediaStream!.addTrack(pluginMediaTrack!);
+			}
 
 			self.eventListener([
 				"type": "track",

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -263,17 +263,17 @@ class iosrtcPlugin : CDVPlugin {
 	@objc(RTCPeerConnection_addIceCandidate:) func RTCPeerConnection_addIceCandidate(_ command: CDVInvokedUrlCommand) {
 		NSLog("iosrtcPlugin#RTCPeerConnection_addIceCandidate()")
 
+		if command.argument(at: 1) == nil {
+			NSLog("iosrtcPlugin#RTCPeerConnection_addIceCandidate() | ERROR: pluginRTCPeerConnection argument is NIL")
+			return;
+		}
+
 		let pcId = command.argument(at: 0) as! Int
 		let candidate = command.argument(at: 1) as! NSDictionary
 		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {
 			NSLog("iosrtcPlugin#RTCPeerConnection_addIceCandidate() | ERROR: pluginRTCPeerConnection with pcId=%@ does not exist", String(pcId))
-			return;
-		}
-
-		if command.argument(at: 1) == nil {
-			NSLog("iosrtcPlugin#RTCPeerConnection_addIceCandidate() | ERROR: pluginRTCPeerConnection argument is NIL")
 			return;
 		}
 

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -272,6 +272,11 @@ class iosrtcPlugin : CDVPlugin {
 			return;
 		}
 
+		if command.argument(at: 1) == nil {
+			NSLog("iosrtcPlugin#RTCPeerConnection_addIceCandidate() | ERROR: pluginRTCPeerConnection argument is NIL")
+			return;
+		}
+
 		self.queue.async { [weak pluginRTCPeerConnection] in
 			pluginRTCPeerConnection?.addIceCandidate(candidate,
 				callback: { (data: NSDictionary) -> Void in
@@ -806,8 +811,8 @@ class iosrtcPlugin : CDVPlugin {
 		if self.pluginMediaStreams[newTrackId] == nil {
 			var rtcMediaStreamTrack = self.pluginMediaStreamTracks[existingTrackId]!.rtcMediaStreamTrack;
 			// twilio uses the sdp local description to map the track ids to the media id.
-			// if the original rtcMediaStreamTrack is not cloned, the rtcPeerConnection 
-			// will not add the track and as such will not be found by Twilio. 
+			// if the original rtcMediaStreamTrack is not cloned, the rtcPeerConnection
+			// will not add the track and as such will not be found by Twilio.
 			// it is unable to do the mapping and find track and thus
 			// will not publish the local track.
 			if pluginMediaStreamTrack?.kind == "video" {


### PR DESCRIPTION
Check if pluginMediaStream had already the new track, otherwise add new track on PluginRTCPeerConnection ontrack.
This improve/fix Janus usage.

Tested using `cordova-plugin-iosrtc` with `www/index.html` modfied to use `js/index-janus.js`.

# Testing

To test `task/janus` branch
```
cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#task/janus --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save
```