### PR TITLE
fix requestPermission returns true if AVAuthorizationStatus is notDetermined #690

### DIFF
--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1246,6 +1246,7 @@ class iosrtcPlugin : CDVPlugin {
 				case AVAuthorizationStatus.authorized:
 					NSLog("PluginGetUserMedia#call() | video authorization: authorized")
 					status = true
+				}
 			}
 
 			if (status) {

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1217,39 +1217,36 @@ class iosrtcPlugin : CDVPlugin {
 
 	@objc(RTCRequestPermission:) func RTCRequestPermission(_ command: CDVInvokedUrlCommand) {
 		DispatchQueue.main.async {
+			var status: Bool = false
 			let audioRequested: Bool = CBool(command.arguments[0] as! Bool)
 			let videoRequested: Bool = CBool(command.arguments[1] as! Bool)
-			var status: Bool = true
 
 			if videoRequested == true {
 				switch AVCaptureDevice.authorizationStatus(for: AVMediaType.video) {
 				case AVAuthorizationStatus.notDetermined:
 					NSLog("PluginGetUserMedia#call() | video authorization: not determined")
-				case AVAuthorizationStatus.authorized:
-					NSLog("PluginGetUserMedia#call() | video authorization: authorized")
-				case AVAuthorizationStatus.denied:
-
-					NSLog("PluginGetUserMedia#call() | video authorization: denied")
-					status = false
 				case AVAuthorizationStatus.restricted:
 					NSLog("PluginGetUserMedia#call() | video authorization: restricted")
-					status = false
+				case AVAuthorizationStatus.denied:
+					NSLog("PluginGetUserMedia#call() | video authorization: denied")
+				case AVAuthorizationStatus.authorized:
+					NSLog("PluginGetUserMedia#call() | video authorization: authorized")
+					status = true
 				}
 			}
 
 			if audioRequested == true {
 				switch AVCaptureDevice.authorizationStatus(for: AVMediaType.audio) {
 				case AVAuthorizationStatus.notDetermined:
-					NSLog("PluginGetUserMedia#call() | audio authorization: not determined")
-				case AVAuthorizationStatus.authorized:
-					NSLog("PluginGetUserMedia#call() | audio authorization: authorized")
-				case AVAuthorizationStatus.denied:
-					NSLog("PluginGetUserMedia#call() | audio authorization: denied")
-					status = false
+				case AVAuthorizationStatus.notDetermined:
+					NSLog("PluginGetUserMedia#call() | video authorization: not determined")
 				case AVAuthorizationStatus.restricted:
-					NSLog("PluginGetUserMedia#call() | audio authorization: restricted")
-					status = false
-				}
+					NSLog("PluginGetUserMedia#call() | video authorization: restricted")
+				case AVAuthorizationStatus.denied:
+					NSLog("PluginGetUserMedia#call() | video authorization: denied")
+				case AVAuthorizationStatus.authorized:
+					NSLog("PluginGetUserMedia#call() | video authorization: authorized")
+					status = true
 			}
 
 			if (status) {

--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1238,7 +1238,6 @@ class iosrtcPlugin : CDVPlugin {
 			if audioRequested == true {
 				switch AVCaptureDevice.authorizationStatus(for: AVMediaType.audio) {
 				case AVAuthorizationStatus.notDetermined:
-				case AVAuthorizationStatus.notDetermined:
 					NSLog("PluginGetUserMedia#call() | video authorization: not determined")
 				case AVAuthorizationStatus.restricted:
 					NSLog("PluginGetUserMedia#call() | video authorization: restricted")


### PR DESCRIPTION
Fix will land in 6.0.22 aka 6 TLS and 8 aka master

# Testing

> cordova plugin remove cordova-plugin-iosrtc --verbose
cordova plugin add https://github.com/cordova-rtc/cordova-plugin-iosrtc#bugs/RTCRequestPermissionnotDetermined --verbose
cordova platform remove ios --no-save
cordova platform add ios --no-save