### PR TITLE
RTCRtpSender: fixed MediaStreamTrack replace

### DIFF
--- a/js/RTCRtpSender.js
+++ b/js/RTCRtpSender.js
@@ -7,7 +7,7 @@ module.exports = RTCRtpSender;
  * Dependencies.
  */
 var exec = require('cordova/exec'),
-	MediaStreamTrack = require('./MediaStreamTrack'),
+	{ MediaStreamTrack } = require('./MediaStreamTrack'),
 	randomNumber = require('random-number').generator({ min: 10000, max: 99999, integer: true });
 
 function RTCRtpSender(pc, data) {

--- a/www/cordova-plugin-iosrtc.js
+++ b/www/cordova-plugin-iosrtc.js
@@ -2953,7 +2953,7 @@ module.exports = RTCRtpSender;
  * Dependencies.
  */
 var exec = _dereq_('cordova/exec'),
-	MediaStreamTrack = _dereq_('./MediaStreamTrack'),
+	{ MediaStreamTrack } = _dereq_('./MediaStreamTrack'),
 	randomNumber = _dereq_('random-number').generator({ min: 10000, max: 99999, integer: true });
 
 function RTCRtpSender(pc, data) {


### PR DESCRIPTION
The problem is [new MediaStreamTrack(result.track)](https://github.com/cordova-rtc/cordova-plugin-iosrtc/blob/master/js/RTCRtpSender.js#L57) uses `MediaStreamTrack` module exports object instead of `MediaStreamTrack ` constructor.