### PR TITLE
fixed RtpSenders inconsistency after removeTrack call

### DIFF
--- a/src/PluginRTCPeerConnection.swift
+++ b/src/PluginRTCPeerConnection.swift
@@ -413,7 +413,6 @@ class PluginRTCPeerConnection : NSObject, RTCPeerConnectionDelegate {
 		}
 
 		self.rtcPeerConnection.removeTrack(pluginRTCRtpSender.rtpSender)
-		self.pluginRTCRtpSenders.removeValue(forKey: pluginRTCRtpSender.id)
 	}
 
 	func addTransceiver(


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeTrack `removeTrack` should not lead to `RTCRtpSender` remove.

This fixes `Cannot find native RTCRtpSender with id=xxxxx` on subsequent `RTCRtpSender.replaceTrack()` call