### PR TITLE
fix: guard against empty senders array

### DIFF
--- a/src/PluginRTCDTMFSender.swift
+++ b/src/PluginRTCDTMFSender.swift
@@ -21,7 +21,9 @@ class PluginRTCDTMFSender : NSObject {
 		// TODO check if new rtcRtpSender can be used one Unified-Plan merged
 		//let streamIds = [streamId]
 		//self.rtcRtpSender = rtcPeerConnection.add(track, streamIds: streamIds);
-		self.rtcRtpSender = rtcPeerConnection.senders[0]
+		if !rtcPeerConnection.senders.isEmpty {
+                self.rtcRtpSender = rtcPeerConnection.senders[0]
+            }
 
 		if self.rtcRtpSender == nil {
 			NSLog("PluginRTCDTMFSender#init() | rtcPeerConnection.createDTMFSenderForTrack() failed")


### PR DESCRIPTION
Guard against an empty senders array in PluginRTCDTMFSender init.