### PR TITLE
use SAI to adjust the top/left corner from the client

### DIFF
--- a/src/PluginMediaStreamRenderer.swift
+++ b/src/PluginMediaStreamRenderer.swift
@@ -198,9 +198,10 @@ class PluginMediaStreamRenderer : NSObject, RTCEAGLVideoViewDelegate {
 		let videoViewLeft: Double = (elementWidth - videoViewWidth) / 2
 		let videoViewTop: Double = (elementHeight - videoViewHeight) / 2
 
+		// use SAI to adjust the top/left corner from the client
 		self.elementView.frame = CGRect(
-			x: CGFloat(elementLeft),
-			y: CGFloat(elementTop),
+			x: CGFloat(elementLeft + self.webView.safeAreaInsets.left),
+			y: CGFloat(elementTop + self.webView.safeAreaInsets.top),
 			width: CGFloat(elementWidth),
 			height: CGFloat(elementHeight)
 		)


### PR DESCRIPTION
This is to solve the problem I encountered when using the iPhone 13 in landscape mode.

When the wkwebview is not full screen, the video was rendered to the left of the actual <video>, due to the rounded corner.