### PR TITLE
use the same MediaStreamTrack on RTCRtpSender

### DIFF
--- a/js/RTCPeerConnection.js
+++ b/js/RTCPeerConnection.js
@@ -610,7 +610,7 @@ RTCPeerConnection.prototype.getOrCreateTrack = function (trackInput) {
 	if (trackInput instanceof MediaStreamTrack) {
 		track = trackInput;
 	} else {
-		track = new MediaStreamTrack(trackInput);
+		track = MediaStreamTrack.findOrCreate(trackInput);
 	}
 
 	this.tracks[id] = track;

--- a/js/RTCRtpSender.js
+++ b/js/RTCRtpSender.js
@@ -57,7 +57,7 @@ RTCRtpSender.prototype.replaceTrack = function (withTrack) {
 
 	return new Promise((resolve, reject) => {
 		function onResultOK(result) {
-			self.track = result.track ? new MediaStreamTrack(result.track) : null;
+			self.track = result.track ? MediaStreamTrack.findOrCreate(result.track) : null;
 			resolve();
 		}
 


### PR DESCRIPTION
this took me lots of time to track down.

under iosrtc, for local media tracks, the normal flow goes:

- app calls gUM
  - iosrtc plugin sends intent/request to native side
  - webrtc does things
  - native side sends OK event to js, containing the track info
  - iosrtc plugin returns to the caller with a `new MediaStreamTrack`
- app tries to add the track in the context of peer-connection/rtp-sender (new sender or replaceTrack)
  - iosrtc plugin sends intent/request to native side
  - webrtc does things
  - native side sends OK event to js
  - iosrtc plugin *should* directly assign the existing track to the peer-connection/rtp-sender
    - but, since the track is not yet on pc, `pc.getOrCreateTrack` then makes `new MediaStreamTrack` with the same id
    - this breaks the spec since the track from gUM is not "object reference equal" to the track linked to rtp-sender

the patch here uses a global map to maintain all "active" tracks, so that the async callback can find the existing tracks.

still, this is a quick and dirty workaround to addresses my own usage.