### PR TITLE
Switch ios-swift-support.js hook to `before_build`

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,8 +19,9 @@
 	</engines>
 
 	<platform name="ios">
-
-		<hook type="after_prepare" src="extra/hooks/iosrtc-swift-support.js" />
+		<!-- Using `before_build` instead of `after_prepare` hook because in some environments the hook could get triggered
+			 before the npm dependencies would be installed, which would then break the build process. -->
+		<hook type="before_build" src="extra/hooks/iosrtc-swift-support.js" />
 
 		<config-file target="config.xml" parent="/*">
 			<feature name="iosrtcPlugin">


### PR DESCRIPTION
Hi!

We had a problem using `cordova-plugin-iosrtc` in our project.

Our project is based on Meteor 3, which had an update from Meteor 2, previously, where the plugin worked without a hitch.

Now Meteor is a special fellow in how it uses cordova; it doesn't utilize the command line tools, but instead manages the build process by itself, using the cordova _library_ to do the project composition and build steps.

Which makes it a bit out of the norm I guess.

But yeah! With Meteor 3, which also brought a big jump in the Node.js version from 14.x to 20+, suddenly this plugin wouldn't build on iOS anymore, because this one hook file for iOS (`extra/hooks/iosrtc-swift-support.js`) would get executed before this plugins' npm dependencies had been installed.

It took a bit for us to figure that one out...

We still don't fully understand why the order of the execution has changed between the Node.js & Meteor versions switch; we just know it did.

Looking at the Cordova hooks documentation: https://cordova.apache.org/docs/en/latest/guide/appdev/hooks/ , the hook `after_prepare` gets run a lot:

<img width="862" alt="image" src="https://github.com/user-attachments/assets/ed0551c6-da66-4057-8b54-1814dc95c6fb" />

(eg. after the prepare step, after the platform add step...) but which then apparently would lead it to be run even before all the deps were installed.

Switching to the `before_build` hook sounded promising, so we gave it a shot, and - it seems to work for us:

<img width="854" alt="image" src="https://github.com/user-attachments/assets/297cc7eb-7be6-4a55-9883-f06bbdc3254a" />

Of course we don't know how this might impact other setups; I am not versed too well in the cordova plugin hooks system, unfortunately. But if this would continue to work for everybody and doesn't bring any downsides it'd be cool if this could be merged, of course, so we wouldn't have to maintain our own fork (and it might of course even help others too, in the future).

Thank you and best wishes everyone!