### PR TITLE
fix RtpSender replaceTrack with null

### DIFF
--- a/src/iosrtcPlugin.swift
+++ b/src/iosrtcPlugin.swift
@@ -1465,13 +1465,14 @@ class iosrtcPlugin : CDVPlugin {
                 return
             }
 
-            if let trackId = trackId, let pluginMediaStreamTrack = self.pluginMediaStreamTracks[trackId] {
+            let pluginMediaStreamTrack = trackId != nil ? self.pluginMediaStreamTracks[trackId!] : nil;
+            if trackId == nil || pluginMediaStreamTrack != nil {
                 pluginRTCRptSender.replaceTrack(pluginMediaStreamTrack)
                 self.emit(command.callbackId,
                           result: CDVPluginResult(
                             status: CDVCommandStatus_OK,
                             messageAs: [
-                                "track": pluginMediaStreamTrack.getJSON()
+                                "track": pluginMediaStreamTrack?.getJSON()
                             ]))
             } else {
                 NSLog("iosrtcPlugin#RTCPeerConnection_RTCRtpSender_replaceTrack() | ERROR: Unable to find track")


### PR DESCRIPTION
#780 make it impossible to do `sender.replaceTrack(null)`